### PR TITLE
[Resolves PW-780 & PW-781] IAM users crash

### DIFF
--- a/services/iam/app/models/tenant.rb
+++ b/services/iam/app/models/tenant.rb
@@ -17,6 +17,7 @@ class Tenant < Iam::ApplicationRecord
   def create_service_tenants
     Ros::Sdk.configured_services.each do |name, service|
       next if name.eql? 'iam'
+
       service::Tenant.create(schema_name: schema_name)
       # TODO: Log a warning if any call fails
     end

--- a/services/iam/app/resources/user_resource.rb
+++ b/services/iam/app/resources/user_resource.rb
@@ -11,11 +11,10 @@ class UserResource < Iam::ApplicationResource
   filter :username
 
   def self.creatable_fields(context)
-    super - %i(attached_policies attached_actions)
+    super - %i[attached_policies attached_actions jwt_payload]
   end
 
   def self.updatable_fields(context)
-    super - %i(attached_policies attached_actions)
+    super - %i[attached_policies attached_actions jwt_payload]
   end
 end
-

--- a/services/iam/spec/dummy/config/application.rb
+++ b/services/iam/spec/dummy/config/application.rb
@@ -21,6 +21,10 @@ module Dummy
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.hosts << 'iam'
+    # NOTE: This is being used to ensure that the requests specs
+    # do not fail due to hosts problems. Not sure if this is the
+    # right way to solve it but must move on
+    config.hosts << 'www.example.com' if Rails.env.test?
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
@@ -33,4 +37,3 @@ module Dummy
     config.api_only = true
   end
 end
-

--- a/services/iam/spec/factories/policies.rb
+++ b/services/iam/spec/factories/policies.rb
@@ -3,5 +3,9 @@
 FactoryBot.define do
   factory :policy do
     name { Faker::Internet.username }
+
+    trait :administrator_access do
+      name { 'AdministratorAccess' }
+    end
   end
 end

--- a/services/iam/spec/factories/users.rb
+++ b/services/iam/spec/factories/users.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     password { Faker::Internet.password }
     console { true }
     api { true }
+
+    trait :administrator_access do
+      policies { [FactoryBot.create(:policy, :administrator_access)] }
+    end
   end
 end
 # TODO: Move to Cognito

--- a/services/iam/spec/policies/policy_policy_spec.rb
+++ b/services/iam/spec/policies/policy_policy_spec.rb
@@ -29,10 +29,7 @@ describe PolicyPolicy do
     end
 
     context 'with the AdministratorAccess' do
-      let(:policy) do
-        FactoryBot.create :policy, name: 'AdministratorAccess'
-      end
-      let(:user) { FactoryBot.create(:user, policies: [policy]) }
+      let(:user) { FactoryBot.create(:user, :administrator_access) }
 
       it { is_expected.to permit(:index)   }
       it { is_expected.to permit(:show)    }

--- a/services/iam/spec/requests/users_spec.rb
+++ b/services/iam/spec/requests/users_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+describe 'users requests', type: :request do
+  describe 'GET index' do
+    let(:body) { JSON.parse(response.body) }
+    context 'unauthenticated user' do
+      before do
+        get '/users'
+      end
+
+      it 'returns unauthenticated' do
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'authenticated user' do
+      before do
+        tenant = FactoryBot.create :tenant
+        cr = {}
+        tenant.switch do
+          user = FactoryBot.create(:user, :administrator_access)
+          cr = user.credentials.create
+        end
+
+        headers = {
+          'Content-Type' => 'application/vnd.api+json',
+          'Authorization' => "Basic #{cr.access_key_id}:#{cr.secret_access_key}"
+        }
+
+        get '/users', headers: headers
+      end
+
+      it 'returns a successful response' do
+        expect(response).to be_successful
+        # TODO: improve reponse test coverage
+        expect(body['data']).to_not be_nil
+      end
+    end
+  end
+
+  describe 'POST create' do
+    let(:body) { JSON.parse(response.body) }
+
+    context 'unauthenticated user' do
+      before do
+        headers = { 'Content-Type' => 'application/vnd.api+json' }
+        post '/users', params: '{}', headers: headers
+      end
+
+      it 'returns unauthenticated' do
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'authenticated user' do
+      before do
+        tenant = FactoryBot.create :tenant
+        cr = {}
+        tenant.switch do
+          user = FactoryBot.create(:user, :administrator_access)
+          cr = user.credentials.create
+        end
+
+        headers = {
+          'Content-Type' => 'application/vnd.api+json',
+          'Authorization' => "Basic #{cr.access_key_id}:#{cr.secret_access_key}"
+        }
+
+        post '/users', params: user_data, headers: headers
+      end
+
+      context 'correct params' do
+        let(:user_data) do
+          '{
+            "data": {
+              "type": "users",
+              "attributes": {
+                "username": "nicolas",
+                "time_zone": "SGT"
+              }
+            }
+          }'
+        end
+
+        it 'returns a successful response' do
+          expect(response).to be_successful
+          # TODO: improve reponse test coverage
+          expect(response.code).to eq '201'
+          expect(body['data']).to_not be_nil
+        end
+      end
+
+      context 'incorrect params' do
+        let(:user_data) do
+          '{
+            "data": {
+              "type": "users",
+              "attributes": {
+                "username": "nicolas",
+                "time_zone": "SGT",
+                "jwt_payload": "hello123"
+              }
+            }
+          }'
+        end
+
+        it 'returns a successful response' do
+          expect(response).to_not be_successful
+          expect(response.code).to eq '400'
+          # TODO: improve reponse test coverage
+          expect(body['errors'][0]['title']).to eq('Param not allowed')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This mostly excludes `jwt_payload` from creatable and updatable fields for IAM users
It adds the first request spec for getting the index and posting to create users.