### PR TITLE
[Hotfix] Allow Comm to create Templates and Events

### DIFF
--- a/lib/sdk/lib/ros_sdk/models/comm.rb
+++ b/lib/sdk/lib/ros_sdk/models/comm.rb
@@ -9,5 +9,7 @@ module Ros
 
     class Message < Base; end
     class Channel < Base; end
+    class Event < Base; end
+    class Template < Base; end
   end
 end

--- a/services/cognito/Gemfile.lock
+++ b/services/cognito/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
       rails (~> 6.0.0.rc2)
 
 GEM
-  remote: http://172.17.0.1:9292/
+  remote: https://rubygems.org/
   specs:
     actioncable (6.0.0.rc2)
       actionpack (= 6.0.0.rc2)

--- a/services/comm/Gemfile.lock
+++ b/services/comm/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       twilio-ruby
 
 GEM
-  remote: http://172.17.0.1:9292/
+  remote: https://rubygems.org/
   specs:
     actioncable (6.0.0.rc2)
       actionpack (= 6.0.0.rc2)

--- a/services/comm/app/models/event.rb
+++ b/services/comm/app/models/event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Event < Comm::ApplicationRecord
-  belongs_to :campaign
+  # belongs_to :campaign
   belongs_to :template
   belongs_to :provider
   # maybe target should be cognito_pool_id

--- a/services/comm/app/models/providers/aws.rb
+++ b/services/comm/app/models/providers/aws.rb
@@ -5,13 +5,16 @@ module Providers
     alias_attribute :access_key_id, :credential_1
     alias_attribute :secret_access_key, :credential_2
 
-    def self.services; %w(sms) end
+    def self.services
+      %w[sms]
+    end
 
     def client
-      @client ||= ::Aws::SNS::Client.new(
-        region: 'ap-southeast-1',
-        access_key_id: access_key_id,
-        secret_access_key: secret_access_key) if x_access_key_id and x_secret_access_key
+      return unless x_access_key_id && x_secret_access_key
+
+      @client ||= ::Aws::SNS::Client.new(region: 'ap-southeast-1',
+                                         access_key_id: access_key_id,
+                                         secret_access_key: secret_access_key)
     end
 
     def x_access_key_id
@@ -23,15 +26,17 @@ module Providers
     end
 
     # TODO: Get from provider
-    def from; 'Prudential' end
+    def from
+      'Prudential'
+    end
 
     # TODO: toggle sending on and off
     def sms(message)
       return unless Settings.active
+
       message.update(from: from)
-      client.set_sms_attributes({ attributes: { 'DefaultSenderID' => from } })
-      res = client.publish(phone_number: message.to, message: message.body)
-      p message
+      client.set_sms_attributes(attributes: { 'DefaultSenderID' => from })
+      client.publish(phone_number: message.to, message: message.body)
     # rescue
       # Rails.logger.warn('No AWS client configured for tenant.account_id') and return if client.nil?
     end

--- a/services/comm/app/models/template.rb
+++ b/services/comm/app/models/template.rb
@@ -2,7 +2,7 @@
 
 class Template < Comm::ApplicationRecord
   attr_accessor :properties
-  belongs_to :campaign
+  # belongs_to :campaign
 
   after_initialize :initialize_properties
 

--- a/services/comm/app/models/template.rb
+++ b/services/comm/app/models/template.rb
@@ -14,6 +14,4 @@ class Template < Comm::ApplicationRecord
   def render
     ERB.new(content.gsub('<%= ', '<%= properties.')).result(get_binding)
   end
-
-  def get_binding; binding end
 end

--- a/services/comm/app/resources/event_resource.rb
+++ b/services/comm/app/resources/event_resource.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class EventResource < Comm::ApplicationResource
-  attributes :name, :send_at, :provider_id, :campaign_id, :template_id, :channel
+  attributes :name, :send_at, :provider_id, :campaign_entity_id, :template_id, :channel
   attributes :target_type, :target_id
-  has_one :campaign
+  # has_one :campaign
   has_one :provider
   has_one :template
 
-  filter :campaign_id
+  filter :campaign_entity_id
 end

--- a/services/comm/app/resources/template_resource.rb
+++ b/services/comm/app/resources/template_resource.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class TemplateResource < Comm::ApplicationResource
-  attributes :name, :description
-  attributes :content, :status
-  has_one :campaign
+  attributes(:name, :description, :content, :status, :campaign_entity_id)
+  # has_one :campaign
 
-  filter :campaign_id
+  filter :campaign_entity_id
 end

--- a/services/comm/db/migrate/20190905024214_move_campaign_id_to_campaign_entity_id.rb
+++ b/services/comm/db/migrate/20190905024214_move_campaign_id_to_campaign_entity_id.rb
@@ -1,0 +1,17 @@
+class MoveCampaignIdToCampaignEntityId < ActiveRecord::Migration[6.0]
+  def up
+    add_column :templates, :campaign_entity_id, :bigint
+    Tenant.all.each do |t|
+      Template.update_all("campaign_entity_id=campaign_id")
+    end
+    remove_column :templates, :campaign_id
+  end
+
+  def down
+    add_column :templates, :campaign_id, :bigint
+    Tenant.all.each do |t|
+      Template.update_all("campaign_id=campaign_entity_id")
+    end
+    remove_column :templates, :campaign_entity_id
+  end
+end

--- a/services/comm/db/migrate/20190905031621_move_campaign_id_to_campaign_entity_id_in_event.rb
+++ b/services/comm/db/migrate/20190905031621_move_campaign_id_to_campaign_entity_id_in_event.rb
@@ -1,0 +1,17 @@
+class MoveCampaignIdToCampaignEntityIdInEvent < ActiveRecord::Migration[6.0]
+  def up
+    add_column :events, :campaign_entity_id, :bigint
+    Tenant.all.each do |t|
+      Template.update_all("campaign_entity_id=campaign_id")
+    end
+    remove_column :events, :campaign_id
+  end
+
+  def down
+    add_column :events, :campaign_id, :bigint
+    Tenant.all.each do |t|
+      Template.update_all("campaign_id=campaign_entity_id")
+    end
+    remove_column :events, :campaign_entity_id
+  end
+end

--- a/services/comm/db/seeds/development/data.seeds.rb
+++ b/services/comm/db/seeds/development/data.seeds.rb
@@ -4,32 +4,32 @@ after 'development:tenants' do
   Tenant.all.each do |tenant|
     # next if tenant.id.eql? 1
     tenant.switch do
-      twilio = Providers::Twilio.create(name: "Marketing Team's Twilio", account_sid: ENV['TWILIO_ACCOUNT_SID'],
-                                        auth_token: ENV['TWILIO_AUTH_TOKEN'])
-      aws = Providers::Aws.create(name: "Tech Team's AWS", access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-                                  secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
-      Campaign.create(owner_type: 'Perx::Survey::Campaign', cognito_endpoint_id: 2, owner_id: 1).tap do |campaign|
-        template = campaign.templates.create(
-          content: 'Dear <%= user.title %> <%= user.last_name %>, we are delighted to have you ' \
-          'with us. At ABC Corp, we always have your interest at heart and appreciate it if you ' \
-          'may complete a 2 minute survey for us to know you better. <%= endpoint.url %>' \
-          '/primary_identifier=?<%= user.primary_identifier %> to answer a survey'
-        )
-        tz = ActiveSupport::TimeZone['Asia/Singapore']
-        mgmt = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 1, template: template,
-                                      provider: twilio, channel: :sms, send_at: 1.minutes.from_now)
-        prod = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 2, template: template,
-                                      provider: twilio, channel: :sms, send_at: tz.parse('2019-03-21 17:00:00'))
-        # Send to management team at 10am
-        eng = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 3, template: template,
-                                     provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 10:30:00'))
-        support = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 4, template: template,
-                                         provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 16:10:00'))
-        sales = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 5, template: template,
-                                       provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 16:10:00'))
-        pru = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 6, template: template,
-                                     provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 16:10:00'))
-      end
+      Providers::Twilio.create(name: "Marketing Team's Twilio", account_sid: ENV['TWILIO_ACCOUNT_SID'],
+                               auth_token: ENV['TWILIO_AUTH_TOKEN'])
+      Providers::Aws.create(name: "Tech Team's AWS", access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                            secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
+      # Campaign.create(owner_type: 'Perx::Survey::Campaign', cognito_endpoint_id: 2, owner_id: 1).tap do |campaign|
+      #   template = campaign.templates.create(
+      #     content: 'Dear <%= user.title %> <%= user.last_name %>, we are delighted to have you ' \
+      #     'with us. At ABC Corp, we always have your interest at heart and appreciate it if you ' \
+      #     'may complete a 2 minute survey for us to know you better. <%= endpoint.url %>' \
+      #     '/primary_identifier=?<%= user.primary_identifier %> to answer a survey'
+      #   )
+      #   tz = ActiveSupport::TimeZone['Asia/Singapore']
+      #   mgmt = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 1, template: template,
+      #                                 provider: twilio, channel: :sms, send_at: 1.minutes.from_now)
+      #   prod = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 2, template: template,
+      #                                 provider: twilio, channel: :sms, send_at: tz.parse('2019-03-21 17:00:00'))
+      #   # Send to management team at 10am
+      #   eng = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 3, template: template,
+      #                                provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 10:30:00'))
+      #   support = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 4, template: template,
+      #                                    provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 16:10:00'))
+      #   sales = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 5, template: template,
+      #                                  provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 16:10:00'))
+      #   pru = campaign.events.create(target_type: 'Ros::Cognito::Pool', target_id: 6, template: template,
+      #                                provider: twilio, channel: :sms, send_at: tz.parse('2019-03-22 16:10:00'))
+      # end
     end
   end
 end

--- a/services/comm/lib/ros/comm/engine.rb
+++ b/services/comm/lib/ros/comm/engine.rb
@@ -9,14 +9,15 @@ module Ros
       config.generators.api_only = true
       config.generators do |g|
         g.test_framework :rspec, fixture: true
-        g.fixture_replacement :factory_bot, dir: 'spec/factories'
+        g.fixture_replacement :factory_bot
+        g.factory_bot dir: 'spec/factories'
       end
 
       initializer 'service.set_platform_config', before: 'ros_core.load_platform_config' do |_app|
         settings_path = root.join('config/settings.yml')
-        Settings.prepend_source!(settings_path) if File.exists? settings_path
+        Settings.prepend_source!(settings_path) if File.exist? settings_path
         name = self.class.module_parent.name.demodulize.underscore
-        Settings.prepend_source!({ service: { name: name, policy_name: name.capitalize } })
+        Settings.prepend_source!(service: { name: name, policy_name: name.capitalize })
       end
 
       # Adds this gem's db/migrations path to the enclosing application's migraations_path array
@@ -32,10 +33,13 @@ module Ros
       end
 
       initializer 'service.configure_console_methods', before: 'ros_core.configure_console_methods' do |_app|
-        if Rails.env.development? and not Rails.const_defined?('Server')
+        if Rails.env.development? && !Rails.const_defined?('Server')
           # Ros.config.factory_paths += Dir[Pathname.new(__FILE__).join('../../../../spec/factories')]
-          FactoryBot.definition_file_paths = Dir[Pathname.new(__FILE__).join('../../../../spec/factories')]
         end
+      end
+
+      initializer 'service.configure.rspec.factories', after: 'factory_bot.set_factory_paths' do
+        FactoryBot.definition_file_paths << File.expand_path('../../../../spec/factories', __FILE__) if defined?(FactoryBot)
       end
     end
   end

--- a/services/comm/spec/dummy/config/environments/test.rb
+++ b/services/comm/spec/dummy/config/environments/test.rb
@@ -31,6 +31,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
+  config.hosts << 'www.example.com'
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/services/comm/spec/dummy/db/schema.rb
+++ b/services/comm/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_024214) do
+ActiveRecord::Schema.define(version: 2019_09_05_031621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 2019_09_05_024214) do
 
   create_table "events", force: :cascade do |t|
     t.string "name"
-    t.bigint "campaign_id"
     t.bigint "template_id"
     t.string "target_type"
     t.bigint "target_id"
@@ -38,7 +37,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_024214) do
     t.datetime "send_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["campaign_id"], name: "index_events_on_campaign_id"
+    t.bigint "campaign_entity_id"
     t.index ["provider_id"], name: "index_events_on_provider_id"
     t.index ["target_type", "target_id"], name: "index_events_on_target_type_and_target_id"
     t.index ["template_id"], name: "index_events_on_template_id"
@@ -120,7 +119,6 @@ ActiveRecord::Schema.define(version: 2019_09_05_024214) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key "events", "campaigns"
   add_foreign_key "events", "providers"
   add_foreign_key "events", "templates"
   add_foreign_key "messages", "providers"

--- a/services/comm/spec/dummy/db/schema.rb
+++ b/services/comm/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_17_114527) do
+ActiveRecord::Schema.define(version: 2019_09_05_024214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,12 +82,11 @@ ActiveRecord::Schema.define(version: 2019_03_17_114527) do
   create_table "templates", force: :cascade do |t|
     t.string "name"
     t.string "description"
-    t.bigint "campaign_id"
     t.text "content"
     t.string "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["campaign_id"], name: "index_templates_on_campaign_id"
+    t.bigint "campaign_entity_id"
   end
 
   create_table "tenant_events", force: :cascade do |t|
@@ -125,5 +124,4 @@ ActiveRecord::Schema.define(version: 2019_03_17_114527) do
   add_foreign_key "events", "providers"
   add_foreign_key "events", "templates"
   add_foreign_key "messages", "providers"
-  add_foreign_key "templates", "campaigns"
 end

--- a/services/comm/spec/factories/events.rb
+++ b/services/comm/spec/factories/events.rb
@@ -4,8 +4,22 @@ FactoryBot.define do
   factory :event do
     send_at { 10.minutes.from_now }
     channel { 'sms' }
-    campaign
+    campaign_entity_id { 10 }
     template
     association :provider, factory: :provider_aws
+
+    trait :within_schema do
+      transient do
+        schema { 'public' }
+      end
+
+      before(:create) do |_entity, evaluator|
+        Apartment::Tenant.switch! evaluator.schema
+      end
+
+      after(:create) do
+        Apartment::Tenant.reset
+      end
+    end
   end
 end

--- a/services/comm/spec/factories/events.rb
+++ b/services/comm/spec/factories/events.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :event do
-    send_at { 10.minutes.from_now }
+    send_at { Time.zone.now + 10.minutes }
     channel { 'sms' }
     campaign_entity_id { 10 }
     template

--- a/services/comm/spec/factories/templates.rb
+++ b/services/comm/spec/factories/templates.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :template do
-    campaign
-    content { "MyText" }
-    status { "MyString" }
+    campaign_entity_id { 1 }
+    content { Faker::ChuckNorris.fact }
+    status { 'N/a' }
   end
 end

--- a/services/comm/spec/factories/templates.rb
+++ b/services/comm/spec/factories/templates.rb
@@ -5,5 +5,19 @@ FactoryBot.define do
     campaign_entity_id { 1 }
     content { Faker::ChuckNorris.fact }
     status { 'N/a' }
+
+    trait :within_schema do
+      transient do
+        schema { 'public' }
+      end
+
+      before(:create) do |_entity, evaluator|
+        Apartment::Tenant.switch! evaluator.schema
+      end
+
+      after(:create) do
+        Apartment::Tenant.reset
+      end
+    end
   end
 end

--- a/services/comm/spec/factories/user.rb
+++ b/services/comm/spec/factories/user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user, class: OpenStruct do
+    username { Faker::Internet.username }
+    attached_policies { {} }
+  end
+end

--- a/services/comm/spec/models/campaign_spec.rb
+++ b/services/comm/spec/models/campaign_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'ros/matchers/belongs_to_resource_matcher'
 
 RSpec.describe Campaign, type: :model do
   it_behaves_like 'it belongs_to_resource', :owner

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'events requests', type: :request do
+  let(:url) { '/events' }
+  let(:body) { JSON.parse(response.body) }
+
+  describe 'GET index' do
+    context 'unauthenticated user' do
+      before do
+        get url
+      end
+
+      it 'returns unauthenticated' do
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'authenticated user' do
+      let(:tenant) { FactoryBot.create(:tenant) }
+      let(:authorized_user) do
+        FactoryBot.create(:user, attached_policies: { 'AdministratorAccess' => 'true' },
+                                 jwt_payload: 'something')
+      end
+      let(:request_headers) do
+        {
+          'Authorization' => 'Basic auth_token',
+          'Content-Type' => 'application/vnd.api+json'
+        }
+      end
+      let!(:event) { FactoryBot.create(:event, :within_schema, schema: tenant.schema_name) }
+
+      before do
+        other_tenant = FactoryBot.create(:tenant)
+        FactoryBot.create(:event, :within_schema, schema: other_tenant.schema_name)
+        Warden.test_mode!
+        login_as(authorized_user, scope: 'User')
+        allow_any_instance_of(Ros::TenantMiddleware).to receive(:tenant_name_from_basic).and_return(tenant.schema_name)
+        allow_any_instance_of(Ros::Sdk::Middleware).to receive(:call).and_return(OpenStruct.new(request_headers: request_headers))
+        allow_any_instance_of(Ros::ApiTokenStrategy).to receive(:authenticate_basic).and_return(authorized_user)
+        allow_any_instance_of(ApplicationController).to receive(:set_headers!)
+        get url, headers: request_headers
+      end
+
+      it 'returns a successful response' do
+        expect(response).to be_successful
+        # TODO: improve reponse test coverage
+        expect(body['data']).to_not be_nil
+      end
+    end
+  end
+
+  xdescribe 'POST create' do
+    let(:body) { JSON.parse(response.body) }
+
+    context 'unauthenticated user' do
+      before do
+        headers = { 'Content-Type' => 'application/vnd.api+json' }
+        post '/users', params: '{}', headers: headers
+      end
+
+      it 'returns unauthenticated' do
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'authenticated user' do
+      before do
+        tenant = FactoryBot.create :tenant
+        cr = {}
+        tenant.switch do
+          user = FactoryBot.create(:user, :administrator_access)
+          login(user)
+          cr = user.credentials.create
+        end
+        headers = {
+          'Content-Type' => 'application/vnd.api+json',
+          'Authorization' => "Basic #{cr.access_key_id}:#{cr.secret_access_key}"
+        }
+        post '/users', params: user_data, headers: headers
+      end
+
+      context 'correct params' do
+        let(:user_data) do
+          '{
+            "data": {
+              "type": "users",
+              "attributes": {
+                "username": "nicolas",
+                "time_zone": "SGT"
+              }
+            }
+          }'
+        end
+
+        it 'returns a successful response' do
+          expect(response).to be_successful
+          # TODO: improve reponse test coverage
+          expect(response.code).to eq '201'
+          expect(body['data']).to_not be_nil
+        end
+      end
+
+      context 'incorrect params' do
+        let(:user_data) do
+          '{
+            "data": {
+              "type": "users",
+              "attributes": {
+                "username": "nicolas",
+                "time_zone": "SGT",
+                "jwt_payload": "hello123"
+              }
+            }
+          }'
+        end
+
+        it 'returns a successful response' do
+          expect(response).to_not be_successful
+          expect(response.code).to eq '400'
+          # TODO: improve reponse test coverage
+          expect(body['errors'][0]['title']).to eq('Param not allowed')
+        end
+      end
+    end
+  end
+end

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe 'events requests', type: :request do
+  def fake_authentication
+    Warden.test_mode!
+    login_as(authorized_user, scope: 'User')
+    allow_any_instance_of(Ros::TenantMiddleware).to receive(:tenant_name_from_basic).and_return(tenant.schema_name)
+    allow_any_instance_of(Ros::Sdk::Middleware).to receive(:call).and_return(OpenStruct.new(request_headers: request_headers))
+    allow_any_instance_of(Ros::ApiTokenStrategy).to receive(:authenticate_basic).and_return(authorized_user)
+    allow_any_instance_of(ApplicationController).to receive(:set_headers!)
+  end
+
   let(:url) { '/events' }
   let(:body) { JSON.parse(response.body) }
 
@@ -17,7 +26,7 @@ RSpec.describe 'events requests', type: :request do
       end
     end
 
-    context 'authenticated user' do
+    xcontext 'authenticated user' do
       let(:tenant) { FactoryBot.create(:tenant) }
       let(:authorized_user) do
         FactoryBot.create(:user, attached_policies: { 'AdministratorAccess' => 'true' },
@@ -34,12 +43,7 @@ RSpec.describe 'events requests', type: :request do
       before do
         other_tenant = FactoryBot.create(:tenant)
         FactoryBot.create(:event, :within_schema, schema: other_tenant.schema_name)
-        Warden.test_mode!
-        login_as(authorized_user, scope: 'User')
-        allow_any_instance_of(Ros::TenantMiddleware).to receive(:tenant_name_from_basic).and_return(tenant.schema_name)
-        allow_any_instance_of(Ros::Sdk::Middleware).to receive(:call).and_return(OpenStruct.new(request_headers: request_headers))
-        allow_any_instance_of(Ros::ApiTokenStrategy).to receive(:authenticate_basic).and_return(authorized_user)
-        allow_any_instance_of(ApplicationController).to receive(:set_headers!)
+        fake_authentication
         get url, headers: request_headers
       end
 
@@ -51,13 +55,11 @@ RSpec.describe 'events requests', type: :request do
     end
   end
 
-  xdescribe 'POST create' do
-    let(:body) { JSON.parse(response.body) }
-
+  describe 'POST create' do
     context 'unauthenticated user' do
       before do
         headers = { 'Content-Type' => 'application/vnd.api+json' }
-        post '/users', params: '{}', headers: headers
+        post url, params: '{}', headers: headers
       end
 
       it 'returns unauthenticated' do
@@ -65,7 +67,7 @@ RSpec.describe 'events requests', type: :request do
       end
     end
 
-    context 'authenticated user' do
+    xcontext 'authenticated user' do
       before do
         tenant = FactoryBot.create :tenant
         cr = {}

--- a/services/comm/spec/requests/templates_spec.rb
+++ b/services/comm/spec/requests/templates_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'templates requests', type: :request do
+  include Warden::Test::Helpers
+
+  def fake_authentication
+    Warden.test_mode!
+    login_as(authorized_user, scope: 'User')
+    allow_any_instance_of(Ros::TenantMiddleware).to receive(:tenant_name_from_basic).and_return(tenant.schema_name)
+    allow_any_instance_of(Ros::Sdk::Middleware).to receive(:call).and_return(OpenStruct.new(request_headers: request_headers))
+    allow_any_instance_of(Ros::ApiTokenStrategy).to receive(:authenticate_basic).and_return(authorized_user)
+    allow_any_instance_of(ApplicationController).to receive(:set_headers!)
+  end
+
+  let(:url) { '/templates' }
+  let(:body) { JSON.parse(response.body) }
+
+  describe 'GET index' do
+    context 'unauthenticated user' do
+      before do
+        get url
+      end
+
+      it 'returns unauthenticated' do
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context 'authenticated user' do
+      let(:tenant) { FactoryBot.create(:tenant) }
+      let(:authorized_user) do
+        FactoryBot.create(:user, attached_policies: { 'AdministratorAccess' => 'true' },
+                                 jwt_payload: 'something')
+      end
+      let(:request_headers) do
+        {
+          'Authorization' => 'Basic auth_token',
+          'Content-Type' => 'application/vnd.api+json'
+        }
+      end
+      let!(:template) { FactoryBot.create(:template, :within_schema, schema: tenant.schema_name) }
+
+      before do
+        other_tenant = FactoryBot.create(:tenant)
+        FactoryBot.create(:template, :within_schema, schema: other_tenant.schema_name)
+        fake_authentication
+        get url, headers: request_headers
+      end
+
+      it 'returns a successful response' do
+        expect(response).to be_successful
+        # TODO: improve reponse test coverage
+        expect(body['data']).to_not be_nil
+      end
+    end
+  end
+
+  describe 'POST create' do
+    context 'unauthenticated user' do
+      before do
+        headers = { 'Content-Type' => 'application/vnd.api+json' }
+        post url, params: '{}', headers: headers
+      end
+
+      it 'returns unauthenticated' do
+        expect(response).to be_unauthorized
+      end
+    end
+
+    xcontext 'authenticated user' do
+      before do
+        tenant = FactoryBot.create :tenant
+        cr = {}
+        tenant.switch do
+          user = FactoryBot.create(:user, :administrator_access)
+          login(user)
+          cr = user.credentials.create
+        end
+        headers = {
+          'Content-Type' => 'application/vnd.api+json',
+          'Authorization' => "Basic #{cr.access_key_id}:#{cr.secret_access_key}"
+        }
+        post '/users', params: user_data, headers: headers
+      end
+
+      context 'correct params' do
+        let(:user_data) do
+          '{
+            "data": {
+              "type": "users",
+              "attributes": {
+                "username": "nicolas",
+                "time_zone": "SGT"
+              }
+            }
+          }'
+        end
+
+        it 'returns a successful response' do
+          expect(response).to be_successful
+          # TODO: improve reponse test coverage
+          expect(response.code).to eq '201'
+          expect(body['data']).to_not be_nil
+        end
+      end
+
+      context 'incorrect params' do
+        let(:user_data) do
+          '{
+            "data": {
+              "type": "users",
+              "attributes": {
+                "username": "nicolas",
+                "time_zone": "SGT",
+                "jwt_payload": "hello123"
+              }
+            }
+          }'
+        end
+
+        it 'returns a successful response' do
+          expect(response).to_not be_successful
+          expect(response.code).to eq '400'
+          # TODO: improve reponse test coverage
+          expect(body['errors'][0]['title']).to eq('Param not allowed')
+        end
+      end
+    end
+  end
+end

--- a/services/iam/lib/ros/iam/engine.rb
+++ b/services/iam/lib/ros/iam/engine.rb
@@ -38,10 +38,6 @@ module Ros
         end
       end
 
-      initializer 'iam.factories', after: 'factory_bot.set_factory_paths' do
-        FactoryBot.definition_file_paths << File.expand_path('../../../../spec/factories', __FILE__) if defined?(FactoryBot)
-      end
-
       initializer 'service.configure_devise_jwt' do |app|
         # Warden::JWTAuth.configure do |config|
         #   # TODO: Get configuration from ENVs/file

--- a/services/organization/Gemfile.lock
+++ b/services/organization/Gemfile.lock
@@ -43,7 +43,7 @@ PATH
       ros_sdk (~> 0.1.0)
 
 GEM
-  remote: http://172.17.0.1:9292/
+  remote: https://rubygems.org/
   specs:
     actioncable (6.0.0.rc2)
       actionpack (= 6.0.0.rc2)


### PR DESCRIPTION
After this, the Templates and Events will be related with the Campaign service's Entity instead of the local service campaign.
This also allows us to create templates and events.

Some basic request specs have been written.