### PR TITLE
[Resolves] Add cognito user id to controller concern context

### DIFF
--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -60,7 +60,7 @@ module Ros
       # inside JSONAPI resources can reference user with context[:user]
       def context
         {
-          user: ::PolicyUser.new(current_user, cognito_user_id)
+          user: ::PolicyUser.new(current_user, cognito_user_id, params: params)
         }
       end
 

--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -60,8 +60,7 @@ module Ros
       # inside JSONAPI resources can reference user with context[:user]
       def context
         {
-          user: current_user,
-          cognito_user_id: cognito_user_id
+          user: PolicyUser.new(current_user, cognito_user_id)
         }
       end
 

--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -56,9 +56,13 @@ module Ros
         @auth_type ||= ActiveSupport::StringInquirer.new(request.env['HTTP_AUTHORIZATION'].split[0].downcase)
       end
 
-      # Next method is for Pundit; inside JSONAPI resources can reference user with context[:user]
+      # Next method is for Pundit;
+      # inside JSONAPI resources can reference user with context[:user]
       def context
-        { user: current_user }
+        {
+          user: current_user,
+          cognito_user_id: cognito_user_id
+        }
       end
 
       # Custom resource serializer:

--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -60,7 +60,7 @@ module Ros
       # inside JSONAPI resources can reference user with context[:user]
       def context
         {
-          user: PolicyUser.new(current_user, cognito_user_id)
+          user: ::PolicyUser.new(current_user, cognito_user_id)
         }
       end
 

--- a/lib/core/app/models/policy_user.rb
+++ b/lib/core/app/models/policy_user.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PolicyUser
+  attr_reader :iam_user, :cognito_user_id
+  attr_accessor :params
+
+  def initialize(user, cognito_user_id, options = {})
+    @iam_user = user
+    @cognito_user_id = cognito_user_id
+    @params = options[:params]
+  end
+
+  def attached_policies
+    @iam_user.attached_policies
+  end
+
+  def attached_actions
+    @iam_user.attached_actions
+  end
+end


### PR DESCRIPTION
No JIRA issue

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Created PolicyUser class that contains a reference to the iam user as well as the cognito_user_id when this is defined. This class also supports additional params in case we want to do scoped decisions.

# How does the implementation addresses the problem

Once this is merged, the pundit user, instead of being simply an IAM user will be a reference to an instance of the class PolicyUser, which internally has the IAM user and the cognito_user_id.