### PR TITLE
[hotfix] adjust factory_name

### DIFF
--- a/lib/core/spec/shared/models/example_groups.rb
+++ b/lib/core/spec/shared/models/example_groups.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'application record concern' do
   let(:underscore_name) { described_class.name.underscore }
   let(:urn) { "urn:#{partition_name}:#{service_name}:#{region}:#{account_id}:#{underscore_name}" }
 
-  let(:factory_name) { described_class.name.downcase.to_sym }
+  let(:factory_name) { described_class.name.underscore.to_sym }
 
   it 'has a factory' do
     expect { create(factory_name) }.not_to raise_error(KeyError)


### PR DESCRIPTION
# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
Adjust the way how `factory_name` generated

# How does the implementation addresses the problem
Previously the `factory_name` was generated incorrectly for `ModelsLikeThis` => `:modelslikethis`
Now it's `:models_like_this`