### PR TITLE
[PW-1309] Apply shared examples to core model specs

### DIFF
--- a/lib/core/spec/shared/models/example_groups.rb
+++ b/lib/core/spec/shared/models/example_groups.rb
@@ -36,6 +36,11 @@ RSpec.shared_examples 'application record concern' do
       expect(described_class.urn_base).not_to be_nil
     end
 
+    it 'respond to urn_id and its is not nil' do
+      expect(described_class.respond_to?(:urn_id)).to be_truthy
+      expect(described_class.urn_id).not_to be_nil
+    end
+
     it 'related to current tennant' do
       expect(described_class.current_tenant).to eq(tenant)
     end
@@ -43,11 +48,6 @@ RSpec.shared_examples 'application record concern' do
     it 'respond to to_urn and its valid' do
       expect(described_class.respond_to?(:to_urn)).to be_truthy
       expect(described_class.to_urn).to eq(urn)
-    end
-
-    it 'respond to urn_id and its valid' do
-      expect(described_class.respond_to?(:urn_id)).to be_truthy
-      expect(described_class.urn_id).to eq(:id).or end_with('_id')
     end
   end
 

--- a/lib/core/spec/shared/models/example_groups.rb
+++ b/lib/core/spec/shared/models/example_groups.rb
@@ -44,12 +44,17 @@ RSpec.shared_examples 'application record concern' do
       expect(described_class.respond_to?(:to_urn)).to be_truthy
       expect(described_class.to_urn).to eq(urn)
     end
+
+    it 'respond to urn_id and its valid' do
+      expect(described_class.respond_to?(:urn_id)).to be_truthy
+      expect(described_class.urn_id).to eq(:id).or end_with('_id')
+    end
   end
 
   context 'instance methods' do
     it 'converts to urn' do
       expect(subject.respond_to?(:to_urn)).to be_truthy
-      expect(subject.to_urn).to eq("#{urn}/#{subject.id}")
+      expect(subject.to_urn).to eq("#{urn}/#{subject.send(described_class.urn_id)}")
     end
 
     it 'related to valid tenant' do

--- a/services/cognito/spec/factories/endpoints.rb
+++ b/services/cognito/spec/factories/endpoints.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :endpoint do
     url { 'http://localhost:3000/test' }
-    tenant
     target_type { 'Survey::Campaign' }
     target_id { 1 }
     properties { '' }

--- a/services/cognito/spec/models/endpoint_spec.rb
+++ b/services/cognito/spec/models/endpoint_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Endpoint, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:subject) { create(factory_name) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/cognito/spec/models/identifier_spec.rb
+++ b/services/cognito/spec/models/identifier_spec.rb
@@ -3,5 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Identifier, type: :model do
+  let(:user) { create(:user) }
+
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:subject) { create(factory_name, user_id: user.id) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/cognito/spec/models/pool_spec.rb
+++ b/services/cognito/spec/models/pool_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Pool, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:subject) { create(factory_name) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/cognito/spec/models/tenant_spec.rb
+++ b/services/cognito/spec/models/tenant_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Tenant, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:subject) { tenant }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/cognito/spec/models/user_pool_spec.rb
+++ b/services/cognito/spec/models/user_pool_spec.rb
@@ -3,5 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe UserPool, type: :model do
+  let(:user) { create(:user) }
+  let(:pool) { create(:pool) }
+
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:subject) { create(factory_name, user_id: user.id, pool_id: pool.id) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/cognito/spec/models/user_spec.rb
+++ b/services/cognito/spec/models/user_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:subject) { create(factory_name) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/comm/spec/models/campaign_spec.rb
+++ b/services/comm/spec/models/campaign_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Campaign, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
+  end
+
   it_behaves_like 'it belongs_to_resource', :owner
   it_behaves_like 'it belongs_to_resource', :cognito_endpoint
 end

--- a/services/comm/spec/models/event_spec.rb
+++ b/services/comm/spec/models/event_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/comm/spec/models/message_spec.rb
+++ b/services/comm/spec/models/message_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Message, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/comm/spec/models/provider_spec.rb
+++ b/services/comm/spec/models/provider_spec.rb
@@ -5,3 +5,23 @@ require 'rails_helper'
 RSpec.describe Provider, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end
+
+RSpec.describe Providers::Aws, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:factory_name) { :provider_aws }
+    let!(:subject) { create(factory_name) }
+  end
+
+  pending "add some examples to (or delete) #{__FILE__}"
+end
+
+RSpec.describe Providers::Twilio, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let(:factory_name) { :provider_twilio }
+    let!(:subject) { create(factory_name) }
+  end
+
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/services/comm/spec/models/template_spec.rb
+++ b/services/comm/spec/models/template_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Template, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
+  end
+
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/services/iam/spec/models/root_spec.rb
+++ b/services/iam/spec/models/root_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Root, type: :model do
-  it 'should do a bunch of things' do
-    # expect(1).to eq(2)
+  include_examples 'application record concern' do
+    let(:tenant) { create(:tenant, root: subject) }
+    let!(:subject) { create(factory_name) }
   end
 end

--- a/services/iam/spec/models/user_spec.rb
+++ b/services/iam/spec/models/user_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  before do
-    create :user
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
   end
 
   describe 'validations' do

--- a/services/organization/spec/models/branch_spec.rb
+++ b/services/organization/spec/models/branch_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Branch, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
+  end
+
   describe 'associations' do
     it { is_expected.to belong_to(:org) }
   end

--- a/services/organization/spec/models/org_spec.rb
+++ b/services/organization/spec/models/org_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Org, type: :model do
+  include_examples 'application record concern' do
+    let(:tenant) { Tenant.first }
+    let!(:subject) { create(factory_name) }
+  end
+
   describe 'associations' do
     it { is_expected.to have_many(:branches) }
   end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[RSpec Shared Examples for Core Application Record Concern](https://perxtechnologies.atlassian.net/browse/PW-1309)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
All model specs are now include shared example groups from ApplicationRecordConcern.
No new model specs were added in this PR, only existing were refactored.

There's also no shared examples for the Storage service yet because I'm working on specs for this service on another branch `storage_request_specs`.

# How does the implementation addresses the problem
Model specs are now unified and more robust.