### PR TITLE
[PW-1356] Endpoint for getting the current tenant properties before sign-in

### DIFF
--- a/services/iam/Gemfile.lock
+++ b/services/iam/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       ros_sdk (~> 0.1.0)
 
 GEM
-  remote: http://localhost:9292/
+  remote: https://rubygems.org/
   specs:
     actioncable (6.0.0.rc2)
       actionpack (= 6.0.0.rc2)

--- a/services/iam/app/policies/tenant_policy.rb
+++ b/services/iam/app/policies/tenant_policy.rb
@@ -1,3 +1,16 @@
 # frozen_string_literal: true
 
-class TenantPolicy < Iam::ApplicationPolicy; end
+class TenantPolicy < Iam::ApplicationPolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user  = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.where(id: user.iam_user.current_tenant.id)
+    end
+  end
+end

--- a/services/iam/app/resources/tenant_resource.rb
+++ b/services/iam/app/resources/tenant_resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TenantResource < Iam::ApplicationResource
-  attributes :account_id, :root_id, :alias, :name, :properties # :locale
+  attributes :account_id, :root_id, :alias, :name, :display_properties # :locale
 
   filter :schema_name
 


### PR DESCRIPTION
[Endpoint for getting the current tenant properties before sign-in](https://perxtechnologies.atlassian.net/browse/PW-1356)

- Updated Tenant Policy to scope the requests to requester's tenant id
- Updated `properties` to `display_properties`

# How does the implementation addresses the problem

After merging this, requests to tenant's endpoints will be scoped to the requestor's tenant id. It also updates the display properties to be serialised instead of properties, since we've agreed that properties would be used for internal behaviour while display properties would be used for external data (namely front end requirements)
