### PR TITLE
[PW-1351] Create Rspec Shared Context for Cognito user

### DIFF
--- a/lib/core/spec/shared/requests/example_groups.rb
+++ b/lib/core/spec/shared/requests/example_groups.rb
@@ -74,6 +74,23 @@ RSpec.shared_context 'authorized user' do
   end
 end
 
+RSpec.shared_context 'cognito_user' do
+  let(:authorized_user) { build(:iam_user, :with_administrator_policy) }
+  let(:cognito_user_id) { 1 }
+  let(:current_jwt) do
+    jwt = Ros::Jwt.new(authorized_user.jwt_payload)
+    jwt.add_claims('sub_cognito' => "urn:perx:cognito::222222222:user/#{cognito_user_id}")
+    jwt.add_claims('act_cognito' => 'act_hello')
+  end
+
+  let(:request_headers) do
+    {
+      'Authorization' => "Bearer #{current_jwt.encode}",
+      'Content-Type' => 'application/vnd.api+json'
+    }
+  end
+end
+
 RSpec.shared_context 'unauthorized user' do
   let(:request_headers) do
     {

--- a/lib/core/spec/shared/requests/example_groups.rb
+++ b/lib/core/spec/shared/requests/example_groups.rb
@@ -74,7 +74,7 @@ RSpec.shared_context 'authorized user' do
   end
 end
 
-RSpec.shared_context 'cognito_user' do
+RSpec.shared_context 'cognito user' do
   let(:authorized_user) { build(:iam_user, :with_administrator_policy) }
   let(:cognito_user_id) { 1 }
   let(:current_jwt) do


### PR DESCRIPTION
[Create Rspec Shared Context for Cognito user](https://perxtechnologies.atlassian.net/browse/PW-1351)

- Created rspec shared context to log in as cognito user 

# How does the implementation addresses the problem

This shared example is needed as when a user posts a new survey answer/game transaction, the model resource tries to grab the `cognito_user_id` which is stored in the JWT token. If the `user_id` isn't here, the response fails and user_id is a compulsory field on the model.
