### PR TITLE
Pw 1539 extract json api as a lib core spec helper method

### DIFF
--- a/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
+++ b/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
@@ -74,18 +74,6 @@ module Ros
               context 'Authenticated user' do
                 include_context 'authorized user'
 
-                # NOTE: Extract and make this a helper method on lib/core/spec/support/helpers/json_helper.rb
-                def jsonapi_data(object, remove = false, *except_attributes)
-                  args = %i[id created_at updated_at]
-                  except_attributes.append(*args) if remove
-                  {
-                    data: {
-                      type: object.class.name.underscore.pluralize,
-                      attributes: object.attributes.except(*except_attributes.map(&:to_s))
-                    }
-                  }.to_json
-                end
-
                 let(:model_data) { build(:#{name}) }
 
                 before do

--- a/lib/core/spec/support/helpers/api_json_helper.rb
+++ b/lib/core/spec/support/helpers/api_json_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ApiJsonSpecHelper
+  def jsonapi_data(object, remove = false, *except_attributes)
+    args = %i[id created_at updated_at]
+    except_attributes.append(*args) if remove
+    {
+      data: {
+        type: object.class.name.underscore.pluralize,
+        attributes: object.attributes.except(*except_attributes.map(&:to_s))
+      }
+    }.to_json
+  end
+end

--- a/lib/core/spec/support/helpers/json_api_helper.rb
+++ b/lib/core/spec/support/helpers/json_api_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ApiJsonSpecHelper
+module JsonApiSpecHelper
   def jsonapi_data(object, remove = false, *except_attributes)
     args = %i[id created_at updated_at]
     except_attributes.append(*args) if remove

--- a/lib/core/spec/support/load_helpers.rb
+++ b/lib/core/spec/support/load_helpers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.include ApiJsonSpecHelper
+  config.include JsonApiSpecHelper
   if defined?(Devise)
     config.include LoginSpecHelper
     config.include Devise::Test::IntegrationHelpers, type: :request

--- a/lib/core/spec/support/load_helpers.rb
+++ b/lib/core/spec/support/load_helpers.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-if defined?(Devise)
-  RSpec.configure do |config|
+RSpec.configure do |config|
+  config.include ApiJsonSpecHelper
+  if defined?(Devise)
     config.include LoginSpecHelper
     config.include Devise::Test::IntegrationHelpers, type: :request
   end

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -48,16 +48,6 @@ RSpec.describe 'Events', type: :request do
       context 'Authenticated user' do
         include_context 'authorized user'
 
-        def jsonapi_data(object, remove = false, *except_attributes)
-          except_attributes.append(:id, :created_at, :updated_at) if remove
-          {
-            data: {
-              type: object.class.name.underscore.pluralize,
-              attributes: object.attributes.except(*except_attributes.map(&:to_s))
-            }
-          }.to_json
-        end
-
         context 'correct params' do
           it 'returns the correct response and payload' do
             mock_authentication if mock

--- a/services/comm/spec/requests/templates_spec.rb
+++ b/services/comm/spec/requests/templates_spec.rb
@@ -48,16 +48,6 @@ RSpec.describe 'Templates', type: :request do
       context 'Authenticated user' do
         include_context 'authorized user'
 
-        def jsonapi_data(object, remove = false, *except_attributes)
-          except_attributes.append(:id, :created_at, :updated_at) if remove
-          {
-            data: {
-              type: object.class.name.underscore.pluralize,
-              attributes: object.attributes.except(*except_attributes.map(&:to_s))
-            }
-          }.to_json
-        end
-
         context 'correct params' do
           it 'returns the correct response and payload' do
             mock_authentication if mock


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Extract json api as a lib core spec helper method](https://perxtechnologies.atlassian.net/browse/PW-1539)

# Describe the changes made. What does this PR changes that might be critical.
# If any critical decisions have been made, make sure you explain the rationale
# for these decisions.

- Extract `json_api` as a lib core spec helper method
- Remove places where `json_api` is defined

# How does the implementation addresses the problem

Makes our code more DRY. Developers don't have to define `json_api` in their request specs everytime.
