### PR TITLE
[PW-1635] Modify fluentd_avro_logger to support HTTP transport

### DIFF
--- a/lib/core/config/settings.yml
+++ b/lib/core/config/settings.yml
@@ -13,7 +13,8 @@ event_logging:
   provider: fluentd
   config:
     host: fluentd
-    port: 24224
+    port: 9880
+    transport: http
     schemas_path: doc/schemas/cloud_events
     name: events-log
     schema_registry_url: http://kafkastack:8081

--- a/lib/core/lib/ros/cloudevents/fluentd_avro_logger.rb
+++ b/lib/core/lib/ros/cloudevents/fluentd_avro_logger.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'base64'
+require 'logger'
+require 'msgpack'
+require 'faraday'
 require 'fluent-logger'
 require 'avro_turf/messaging'
 
@@ -15,40 +18,92 @@ module Ros
       end
     end
 
-    class FluentdAvroLogger
-      class << self
-        attr_reader :logger, :cloudevents_specversion, :avro
+    # A fluentd logger send reocrds using fluentd's HTTP input protocol
+    class FluentHttpLogger < Fluent::Logger::LoggerBase
+      def initialize(tag_prefix = nil, options)
+        super()
 
-        # rubocop:disable Metrics/ParameterLists
-        def configure(name: nil, host: nil, port: 24_224, schema_registry_url: nil, schemas_path: nil,
-                      cloudevents_specversion: '0.4-wip')
-          @avro = AvroTurf::Messaging.new(registry_url: schema_registry_url, schemas_path: schemas_path)
-          @cloudevents_specversion = cloudevents_specversion
-          @logger = Fluent::Logger::FluentLogger.new(name, host: host, port: port)
+        @tag_prefix = tag_prefix
+        @host = options[:host] || 'localhost'
+        @port = options[:port] || 9880
+
+        @msgpack_factory = MessagePack::Factory.new
+
+        if options[:logger]
+          @logger = options[:logger]
+        else
+          @logger = ::Logger.new(STDERR)
+          if options[:debug]
+            @logger.level = ::Logger::DEBUG
+          else
+            @logger.level = ::Logger::INFO
+          end
         end
-        # rubocop:enable Metrics/ParameterLists
+
+        @conn = Faraday.new(
+          "http://#{@host}:#{@port}",
+          {
+            headers: {'Content-Type' => 'application/msgpack'},
+            request: {
+              open_timeout: 2,   # opening a connection
+              timeout: 5         # waiting for response
+            }
+          }
+        )
       end
 
-      def initialize(source)
+      def post_with_time(tag, map, time)
+        record = @msgpack_factory.dump(map)
+        tag = "#{@tag_prefix}.#{tag}" if @tag_prefix
+        @conn.post("/#{tag}", body=record) {|req|
+          req.params['time'] = time.to_f
+        }
+      end
+    end
+
+    class FluentdAvroLogger
+
+      # source: source field for event, also used as tag of fluentd record
+      # options: hash of configurations
+      def initialize(source, options)
         @source = source
+        @host = options[:host]
+        @port = options[:port]
+        @schema_registry_url = options[:schema_registry_url]
+        @schemas_path = options[:schemas_path]
+        @transport = (options[:transport] || 'http').downcase
+        @logger = options[:logger] || ::Logger.new(STDOUT)
+        @cloudevents_specversion = options[:cloudevents_specversion] || '0.4-wip'
+        @tag_prefix = options[:name]
+
+        fluentd_logger_options = {
+          :host => @host,
+          :port => @port,
+          :logger => @logger
+        }
+        if @transport.eql?('http')
+          @fluentd_logger = FluentHttpLogger.new(@tag_prefix, fluentd_logger_options)
+        else
+          @fluentd_logger = Fluent::Logger::FluentLogger.new(@tag_prefix, fluentd_logger_options)
+        end
+
+        @avro = AvroTurf::Messaging.new(registry_url: @schema_registry_url, schemas_path: @schemas_path)
       end
 
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
-      def log_event(type, id, data, subject: nil, time: Time.zone.now)
+      def log_event(type, id, data, subject: nil, time: Time.now)
         event = Event.new
         event.source = @source
-        event.specversion = self.class.cloudevents_specversion
+        event.specversion = @cloudevents_specversion
         event.type = type
-        event.id = id
+        event.id = id.to_s
         event.subject = subject
         event.datacontenttype = 'application/avro'
         event.datacontentencoding = 'Base64'
         event.time = time.strftime('%Y-%m-%dT%H:%M:%S.%L%z')
-        # binding.pry
-        event.data = Base64.encode64(self.class.avro.encode(data, schema_name: type, subject: type + '-value'))
-        # binding.pry
-        self.class.logger.post(@source, event.to_h)
+        event.data = Base64.encode64(@avro.encode(data, schema_name: type, subject: type + '-value'))
+        @fluentd_logger.post_with_time(@source, event.to_h, time)
       end
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize

--- a/lib/core/lib/ros/core/engine.rb
+++ b/lib/core/lib/ros/core/engine.rb
@@ -240,8 +240,8 @@ module Ros
         if Settings.event_logging.enabled
           if Settings.event_logging.provider.eql? 'fluentd'
             require_relative '../cloudevents/fluentd_avro_logger'
-            Ros::CloudEvents::FluentdAvroLogger.configure(Settings.event_logging.config.to_h)
-            Rails.configuration.x.event_logger = Ros::CloudEvents::FluentdAvroLogger.new(Settings.service.name)
+            Rails.configuration.x.event_logger = Ros::CloudEvents::FluentdAvroLogger.new(Settings.service.name,
+              Settings.event_logging.config)
           end
         end
       end


### PR DESCRIPTION
This PR allow the avro logger to use HTTP protocol to send cloud event records to fluentd.