### PR TITLE
[PW-1638] Can't perform actions with basic root token

### DIFF
--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -13,7 +13,6 @@ module Ros
       before_action :authenticate_it!
       after_action :set_headers!
 
-
       def authenticate_it!
         return unless (@current_user = request.env['warden'].authenticate!(:api_token))
 

--- a/lib/core/app/models/policy_user.rb
+++ b/lib/core/app/models/policy_user.rb
@@ -17,4 +17,8 @@ class PolicyUser
   def attached_actions
     @iam_user.attached_actions
   end
+
+  def root?
+    @iam_user.class.name.eql? 'Root'
+  end
 end

--- a/lib/core/app/models/policy_user.rb
+++ b/lib/core/app/models/policy_user.rb
@@ -11,11 +11,11 @@ class PolicyUser
   end
 
   def attached_policies
-    @iam_user.attached_policies
+    @iam_user&.attached_policies || {}
   end
 
   def attached_actions
-    @iam_user.attached_actions
+    @iam_user&.attached_actions || {}
   end
 
   def root?

--- a/lib/core/app/policies/ros/application_policy.rb
+++ b/lib/core/app/policies/ros/application_policy.rb
@@ -100,9 +100,8 @@ module Ros
     # end
     #
 
-    # rubocop:disable Metrics/AbcSize
     def check_action(action)
-      return true if user.class.name.eql? 'Root'
+      return true if user.root?
 
       user_policies = user&.attached_policies || {}
       user_actions = user&.attached_actions || {}
@@ -110,7 +109,6 @@ module Ros
       (user_policies.keys & accepted_policies(action)).any? ||
         (user_actions.keys & accepted_actions(action)).any?
     end
-    # rubocop:enable Metrics/AbcSize
 
     def accepted_policies(action)
       self.class.accepted_policies[action] || []

--- a/lib/core/app/policies/ros/application_policy.rb
+++ b/lib/core/app/policies/ros/application_policy.rb
@@ -103,8 +103,8 @@ module Ros
     def check_action(action)
       return true if user.root?
 
-      user_policies = user&.attached_policies || {}
-      user_actions = user&.attached_actions || {}
+      user_policies = user.attached_policies
+      user_actions = user.attached_actions
 
       (user_policies.keys & accepted_policies(action)).any? ||
         (user_actions.keys & accepted_actions(action)).any?

--- a/services/iam/spec/policies/policy_policy_spec.rb
+++ b/services/iam/spec/policies/policy_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PolicyPolicy do
   let(:policy) { create(:policy) }
 
   context 'for a visitor' do
-    let(:user) { nil }
+    let(:user) { PolicyUser.new(nil, nil) }
 
     it { is_expected.to_not permit(:index)   }
     it { is_expected.to_not permit(:show)    }
@@ -19,7 +19,7 @@ RSpec.describe PolicyPolicy do
 
   context 'for a user' do
     context 'root' do
-      let(:user) { create(:root) }
+      let(:user) { PolicyUser.new(create(:root), nil) }
 
       it { is_expected.to permit(:index)   }
       it { is_expected.to permit(:show)    }
@@ -29,7 +29,7 @@ RSpec.describe PolicyPolicy do
     end
 
     context 'with the AdministratorAccess' do
-      let(:user) { create(:user, :administrator_access) }
+      let(:user) { PolicyUser.new(create(:user, :administrator_access), nil) }
 
       it { is_expected.to permit(:index)   }
       it { is_expected.to permit(:show)    }
@@ -39,10 +39,8 @@ RSpec.describe PolicyPolicy do
     end
 
     context 'with the IamFullAccess' do
-      let(:policy) do
-        create :policy, name: 'IamFullAccess'
-      end
-      let(:user) { create(:user, policies: [policy]) }
+      let(:policy) { create :policy, name: 'IamFullAccess' }
+      let(:user) { PolicyUser.new(create(:user, policies: [policy]), nil) }
 
       it { is_expected.to permit(:index)   }
       it { is_expected.to permit(:show)    }
@@ -52,10 +50,8 @@ RSpec.describe PolicyPolicy do
     end
 
     context 'with the IamReadOnlyAccess' do
-      let(:policy) do
-        create :policy, name: 'IamReadOnlyAccess'
-      end
-      let(:user) { create(:user, policies: [policy]) }
+      let(:policy) { create :policy, name: 'IamReadOnlyAccess' }
+      let(:user) { PolicyUser.new(create(:user, policies: [policy]), nil) }
 
       it { is_expected.to permit(:index)   }
       it { is_expected.to permit(:show)    }


### PR DESCRIPTION
[Can't perform actions with basic root token](https://perxtechnologies.atlassian.net/browse/PW-1638)

- moved the checking if the user is root to the policy user class and using that logic to override the policy checks. We've added this PolicyUser class that keeps information about the iam user and cognito user id, as well as the parms passed in the context. Pundit uses this class as the user context instead of simply the auth'd user. This was causing the logic in the policy to fail because root users do not have attached policies and we were trying to check for it.

# How does the implementation addresses the problem

After merging this, requests coming from a root are always authorised without checking for policies as a root user should have access to the whole platform. After merging this, there is still a [pending issue](https://perxtechnologies.atlassian.net/browse/PW-1678) to be addressed in this topic
