### PR TITLE
Refactor jsonapi data spec helper

### DIFF
--- a/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
+++ b/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
@@ -82,7 +82,7 @@ module Ros
 
                 context 'correct params' do
                   it 'returns a successful response with proper serialized response' do
-                    post_data = jsonapi_data(model_data, true)
+                    post_data = jsonapi_data(model_data, remove: true)
                     post url, headers: request_headers, params: post_data
 
                     expect(response).to be_created
@@ -94,7 +94,7 @@ module Ros
 
                 context 'incorrect params' do
                   it 'returns a failure response and' do
-                    post_data = jsonapi_data(model_data, false)
+                    post_data = jsonapi_data(model_data, remove: false)
                     post url, headers: request_headers, params: post_data
 
                     expect(errors.size).to be_positive

--- a/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
+++ b/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
@@ -82,7 +82,7 @@ module Ros
 
                 context 'correct params' do
                   it 'returns a successful response with proper serialized response' do
-                    post_data = jsonapi_data(model_data, remove: true)
+                    post_data = jsonapi_data(model_data)
                     post url, headers: request_headers, params: post_data
 
                     expect(response).to be_created
@@ -94,7 +94,7 @@ module Ros
 
                 context 'incorrect params' do
                   it 'returns a failure response and' do
-                    post_data = jsonapi_data(model_data, remove: false)
+                    post_data = jsonapi_data(model_data, extra_attributes: { invalid: :param })
                     post url, headers: request_headers, params: post_data
 
                     expect(errors.size).to be_positive

--- a/lib/core/spec/support/helpers/json_api_helper.rb
+++ b/lib/core/spec/support/helpers/json_api_helper.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 module JsonApiSpecHelper
-  def jsonapi_data(object, remove = false, *except_attributes)
+  def jsonapi_data(object, remove = false, except_attributes = [], method = :get)
     args = %i[id created_at updated_at]
     except_attributes.append(*args) if remove
-    {
-      data: {
-        type: object.class.name.underscore.pluralize,
-        attributes: object.attributes.except(*except_attributes.map(&:to_s))
-      }
-    }.to_json
+
+    data = {
+      type: object.class.name.underscore.pluralize,
+      attributes: object.attributes.except(*except_attributes.map(&:to_s))
+    }
+    data[:id] = object.id if %i[put patch].include?(method.downcase.to_sym)
+
+    { data: data }.to_json
   end
 
   def jsonapi_data_with_nested_resources(object, nested_resource, remove = false)

--- a/lib/core/spec/support/helpers/json_api_helper.rb
+++ b/lib/core/spec/support/helpers/json_api_helper.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 module JsonApiSpecHelper
-  def jsonapi_data(object, remove = false, except_attributes = [], method = :get)
+  def jsonapi_data(object, options = {})
+    remove = options.fetch(:remove, false)
+    skip_attributes = options.fetch(:skip_attributes, [])
+    method = options.fetch(:method, :get)
+
     args = %i[id created_at updated_at]
-    except_attributes.append(*args) if remove
+    skip_attributes.append(*args) if remove
 
     data = {
       type: object.class.name.underscore.pluralize,
-      attributes: object.attributes.except(*except_attributes.map(&:to_s))
+      attributes: object.attributes.except(*skip_attributes.map(&:to_s))
     }
     data[:id] = object.id if %i[put patch].include?(method.downcase.to_sym)
 
@@ -15,7 +19,7 @@ module JsonApiSpecHelper
   end
 
   def jsonapi_data_with_nested_resources(object, nested_resource, remove = false)
-    model_jsonapi = JSON.parse(jsonapi_data(object, remove))
+    model_jsonapi = JSON.parse(jsonapi_data(object, remove: remove))
     model_jsonapi['data']['attributes'].merge!(nested_resource)
     model_jsonapi.to_json
   end

--- a/lib/core/spec/support/helpers/json_api_helper.rb
+++ b/lib/core/spec/support/helpers/json_api_helper.rb
@@ -18,9 +18,8 @@ module JsonApiSpecHelper
     { data: data }.to_json
   end
 
-  def jsonapi_data_with_nested_resources(object, nested_resource, remove = false)
-    invalid_params = remove ? {} : { invalid: :param }
-    model_jsonapi = JSON.parse(jsonapi_data(object, extra_attributes: invalid_params))
+  def jsonapi_data_with_nested_resources(object, nested_resource, extra_attributes = {})
+    model_jsonapi = JSON.parse(jsonapi_data(object, extra_attributes: extra_attributes))
     model_jsonapi['data']['attributes'].merge!(nested_resource)
     model_jsonapi.to_json
   end

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Events', type: :request do
             # create an item in DB, duplicate its attributes and create a new one via API
             subject
             model_data = build(:event, provider_id: subject.provider_id, template_id: subject.template_id)
-            post_data = jsonapi_data(model_data, remove: true, skip_attributes: [:status])
+            post_data = jsonapi_data(model_data, skip_attributes: [:status])
             post url, params: post_data, headers: request_headers
             expect(response).to be_created
             expect(model_data.channel).to eq(post_response.channel)
@@ -66,7 +66,7 @@ RSpec.describe 'Events', type: :request do
             mock_authentication if mock
             subject
             model_data = build(:event, provider_id: subject.provider_id, template_id: subject.template_id)
-            post_data = jsonapi_data(model_data, remove: false, skip_attributes: [:status])
+            post_data = jsonapi_data(model_data, extra_attributes: { invalid: :param }, skip_attributes: [:status])
             post url, params: post_data, headers: request_headers
             expect(errors.size).to be_positive
             expect(response).to be_bad_request

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Events', type: :request do
             # create an item in DB, duplicate its attributes and create a new one via API
             subject
             model_data = build(:event, provider_id: subject.provider_id, template_id: subject.template_id)
-            post_data = jsonapi_data(model_data, true, :status)
+            post_data = jsonapi_data(model_data, true, [:status])
             post url, params: post_data, headers: request_headers
             expect(response).to be_created
             expect(model_data.channel).to eq(post_response.channel)
@@ -66,7 +66,7 @@ RSpec.describe 'Events', type: :request do
             mock_authentication if mock
             subject
             model_data = build(:event, provider_id: subject.provider_id, template_id: subject.template_id)
-            post_data = jsonapi_data(model_data, false, :status)
+            post_data = jsonapi_data(model_data, false, [:status])
             post url, params: post_data, headers: request_headers
             expect(errors.size).to be_positive
             expect(response).to be_bad_request

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Events', type: :request do
             # create an item in DB, duplicate its attributes and create a new one via API
             subject
             model_data = build(:event, provider_id: subject.provider_id, template_id: subject.template_id)
-            post_data = jsonapi_data(model_data, true, [:status])
+            post_data = jsonapi_data(model_data, remove: true, skip_attributes: [:status])
             post url, params: post_data, headers: request_headers
             expect(response).to be_created
             expect(model_data.channel).to eq(post_response.channel)
@@ -66,7 +66,7 @@ RSpec.describe 'Events', type: :request do
             mock_authentication if mock
             subject
             model_data = build(:event, provider_id: subject.provider_id, template_id: subject.template_id)
-            post_data = jsonapi_data(model_data, false, [:status])
+            post_data = jsonapi_data(model_data, remove: false, skip_attributes: [:status])
             post url, params: post_data, headers: request_headers
             expect(errors.size).to be_positive
             expect(response).to be_bad_request

--- a/services/comm/spec/requests/templates_spec.rb
+++ b/services/comm/spec/requests/templates_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Templates', type: :request do
             # create an item in DB, duplicate its attributes and create a new one via API
             subject
             model_data = build(:template, content: 'hello mr tambourine')
-            post_data = jsonapi_data(model_data, true, [:status])
+            post_data = jsonapi_data(model_data, remove: true, skip_attributes: [:status])
             post url, params: post_data, headers: request_headers
             expect(response).to be_created
             expect(model_data.content).to eq(post_response.content)

--- a/services/comm/spec/requests/templates_spec.rb
+++ b/services/comm/spec/requests/templates_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Templates', type: :request do
             # create an item in DB, duplicate its attributes and create a new one via API
             subject
             model_data = build(:template, content: 'hello mr tambourine')
-            post_data = jsonapi_data(model_data, remove: true, skip_attributes: [:status])
+            post_data = jsonapi_data(model_data, skip_attributes: [:status])
             post url, params: post_data, headers: request_headers
             expect(response).to be_created
             expect(model_data.content).to eq(post_response.content)
@@ -66,7 +66,7 @@ RSpec.describe 'Templates', type: :request do
             mock_authentication if mock
             subject
             model_data = build(:template, content: 'hello mr tambourine')
-            post_data = jsonapi_data(model_data)
+            post_data = jsonapi_data(model_data, extra_attributes: { invalid: :param })
             post url, params: post_data, headers: request_headers
             expect(errors.size).to be_positive
             expect(response).to be_bad_request

--- a/services/comm/spec/requests/templates_spec.rb
+++ b/services/comm/spec/requests/templates_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Templates', type: :request do
             # create an item in DB, duplicate its attributes and create a new one via API
             subject
             model_data = build(:template, content: 'hello mr tambourine')
-            post_data = jsonapi_data(model_data, true, :status)
+            post_data = jsonapi_data(model_data, true, [:status])
             post url, params: post_data, headers: request_headers
             expect(response).to be_created
             expect(model_data.content).to eq(post_response.content)


### PR DESCRIPTION
- No Ticket

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

**This introduces breaking changes in the `jsonapi_data` spec helper**
- No longer using remove attribute as true/false to combine with expanding arguments. This has been replaced with params passed as options, providing a much clear method signature.

Previously `jsonapi_data` signature was:
```ruby
jsonapi_data(model, true, :params, :to, :exclude)
``` 

Now replaced with:
```ruby
jsonapi_data(model, extra_attributes: { invalid: :param }, skip_attributes [:params, :to, :exclude], method: :put )
```

- default `method` will be `:get` and no changes will be made to the final JSON api data.
- if `:put` or `:patch` are passed, the helper will automatically inject the `id` in the JSON api data.
- `extra_attributes` hash can be used for adding key/values to the JSON api data
- `skip_attributes` array can be used to exclude certain keys from the JSON api data.

# How does the implementation addresses the problem
This refactoring allows us to simplify further the request specs that require JSON api attributes to be written. Now we're able to keep specs DRY for `PATCH`/`PUT` requests