### PR TITLE
update all specs to remove redundant `tenant.switch`

### DIFF
--- a/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
+++ b/lib/core/lib/generators/ros/request_spec/request_spec_generator.rb
@@ -19,7 +19,7 @@ module Ros
 
             describe 'GET index' do
               let(:models_count) { rand(1..5) }
-              let!(:models) { tenant.switch { create_list(:#{name}, models_count) } }
+              let!(:models) { create_list(:#{name}, models_count) }
 
               context 'Unauthenticated user' do
                 include_context 'unauthorized user'
@@ -42,7 +42,7 @@ module Ros
             end
 
             describe 'GET show' do
-              let!(:model) { tenant.switch { create(:#{name}) } }
+              let!(:model) { create(:#{name}) }
               let(:show_url) { url + '/' + model.id.to_s }
 
               context 'Unauthenticated user' do
@@ -127,7 +127,7 @@ module Ros
               context 'Authenticated user' do
                 include_context 'authorized user'
 
-                let!(:model) { tenant.switch { create(:#{name}) } }
+                let!(:model) { create(:#{name}) }
                 let(:delete_url) { url + '/' + model.id.to_s }
 
                 before do

--- a/lib/core/spec/shared/models/example_groups.rb
+++ b/lib/core/spec/shared/models/example_groups.rb
@@ -14,10 +14,6 @@ RSpec.shared_examples 'application record concern' do
     expect { create(factory_name) }.not_to raise_error(KeyError)
   end
 
-  before do
-    tenant.switch!
-  end
-
   # TODO: find the right place
   # context 'after created' do
   #   it 'enqueued job' do

--- a/lib/core/spec/shared/models/example_groups.rb
+++ b/lib/core/spec/shared/models/example_groups.rb
@@ -14,6 +14,10 @@ RSpec.shared_examples 'application record concern' do
     expect { create(factory_name) }.not_to raise_error(KeyError)
   end
 
+  before do
+    tenant.switch!
+  end
+
   # TODO: find the right place
   # context 'after created' do
   #   it 'enqueued job' do

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Events', type: :request do
   let(:mock) { true }
 
   let(:url) { u('/events') }
-  let(:subject) { tenant.switch { create(:event) } }
+  let(:subject) { create(:event) }
   let(:pool) { double(Ros::Cognito::Pool, id: 1) }
 
   before do

--- a/services/comm/spec/requests/templates_spec.rb
+++ b/services/comm/spec/requests/templates_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Templates', type: :request do
   let(:mock) { true }
 
   let(:url) { u('/templates') }
-  let(:subject) { tenant.switch { create(:template) } }
+  let(:subject) { create(:template) }
 
   context 'all' do
     include_context 'jsonapi requests'

--- a/services/iam/spec/requests/tenants_spec.rb
+++ b/services/iam/spec/requests/tenants_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe 'tenants requests', type: :request do
   def auth_headers
     tenant = create :tenant
     cr = {}
-    tenant.switch do
-      user = create(:user, :administrator_access)
-      login(user)
-      cr = user.credentials.create
-    end
+    user = create(:user, :administrator_access)
+    login(user)
+    cr = user.credentials.create
 
     {
       'Content-Type' => 'application/vnd.api+json',

--- a/services/iam/spec/requests/tenants_spec.rb
+++ b/services/iam/spec/requests/tenants_spec.rb
@@ -5,10 +5,7 @@ require 'rails_helper'
 RSpec.describe 'tenants requests', type: :request do
   let(:body) { JSON.parse(response.body) }
 
-  # rubocop:disable Metrics/MethodLength
   def auth_headers
-    tenant = create :tenant
-    cr = {}
     user = create(:user, :administrator_access)
     login(user)
     cr = user.credentials.create
@@ -18,7 +15,6 @@ RSpec.describe 'tenants requests', type: :request do
       'Authorization' => "Basic #{cr.access_key_id}:#{cr.secret_access_key}"
     }
   end
-  # rubocop:enable Metrics/MethodLength
 
   describe 'GET /tenants' do
     context 'unauthenticated user' do

--- a/services/iam/spec/requests/users_spec.rb
+++ b/services/iam/spec/requests/users_spec.rb
@@ -19,11 +19,9 @@ RSpec.describe 'users requests', type: :request do
       before do
         tenant = create :tenant
         cr = {}
-        tenant.switch do
-          user = create(:user, :administrator_access)
-          login(user)
-          cr = user.credentials.create
-        end
+        user = create(:user, :administrator_access)
+        login(user)
+        cr = user.credentials.create
 
         headers = {
           'Content-Type' => 'application/vnd.api+json',
@@ -59,11 +57,9 @@ RSpec.describe 'users requests', type: :request do
       before do
         tenant = create :tenant
         cr = {}
-        tenant.switch do
-          user = create(:user, :administrator_access)
-          login(user)
-          cr = user.credentials.create
-        end
+        user = create(:user, :administrator_access)
+        login(user)
+        cr = user.credentials.create
         headers = {
           'Content-Type' => 'application/vnd.api+json',
           'Authorization' => "Basic #{cr.access_key_id}:#{cr.secret_access_key}"

--- a/services/iam/spec/requests/users_spec.rb
+++ b/services/iam/spec/requests/users_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe 'users requests', type: :request do
 
     context 'authenticated user' do
       before do
-        tenant = create :tenant
-        cr = {}
         user = create(:user, :administrator_access)
         login(user)
         cr = user.credentials.create

--- a/services/iam/spec/requests/users_spec.rb
+++ b/services/iam/spec/requests/users_spec.rb
@@ -55,8 +55,6 @@ RSpec.describe 'users requests', type: :request do
 
     context 'authenticated user' do
       before do
-        tenant = create :tenant
-        cr = {}
         user = create(:user, :administrator_access)
         login(user)
         cr = user.credentials.create


### PR DESCRIPTION
* No ticket

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
Remove all redundant `tenant.switch` from specs

# How does the implementation addresses the problem
We don't need to explicitly switch anymore, everything is automatic after [@412252e](https://github.com/rails-on-services/ros/tree/412252e69596b381511ce04460bb4694c3c9e527)