### PR TITLE
[PW-1879] Can't save a campaign without an audience

### DIFF
--- a/services/comm/app/resources/event_resource.rb
+++ b/services/comm/app/resources/event_resource.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class EventResource < Comm::ApplicationResource
-  attributes :name, :send_at, :provider_id, :campaign_entity_id, :template_id, :channel
+  attributes :name, :send_at, :provider_id, :campaign_entity_id, :template_id, :channel, :pool_id
   attributes :target_type, :target_id
 
   has_one :provider
   has_one :template
 
   filter :campaign_entity_id
+
+  def fetchable_fields
+    super - %i[pool_id]
+  end
 
   def pool_id=(pool_id)
     @model.target_type = 'Ros::Cognito::Pool'

--- a/services/comm/app/resources/event_resource.rb
+++ b/services/comm/app/resources/event_resource.rb
@@ -3,9 +3,19 @@
 class EventResource < Comm::ApplicationResource
   attributes :name, :send_at, :provider_id, :campaign_entity_id, :template_id, :channel
   attributes :target_type, :target_id
-  # has_one :campaign
+
   has_one :provider
   has_one :template
 
   filter :campaign_entity_id
+
+  def pool_id=(pool_id)
+    @model.target_type = 'Ros::Cognito::Pool'
+    @model.target_id = pool_id
+  end
+
+  before_save do
+    # TODO: Make this a valid provider
+    @model.provider_id ||= 1
+  end
 end

--- a/services/comm/spec/factories/events.rb
+++ b/services/comm/spec/factories/events.rb
@@ -4,9 +4,11 @@ FactoryBot.define do
   factory :event do
     send_at { Time.zone.now + 10.minutes }
     channel { 'sms' }
-    campaign_entity_id { 10 }
+    sequence(:campaign_entity_id)
     template
     association :provider, factory: :provider_aws
+    sequence(:target_id)
+    target_type { 'Ros::Cognito::Pool' }
 
     # trait :within_schema do
     #   transient do

--- a/services/comm/spec/models/event_spec.rb
+++ b/services/comm/spec/models/event_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
+  let(:pool) { double(Ros::Cognito::Pool, id: 1) }
+
+  before do
+    allow(Ros::Cognito::Pool).to receive(:where).and_return [pool]
+  end
+
   include_examples 'application record concern' do
     let(:tenant) { Tenant.first }
     let!(:subject) { create(factory_name) }

--- a/services/comm/spec/models/message_spec.rb
+++ b/services/comm/spec/models/message_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Message, type: :model do
+  let(:pool) { double(Ros::Cognito::Pool, id: 1) }
+
+  before do
+    allow(Ros::Cognito::Pool).to receive(:where).and_return [pool]
+  end
+
   include_examples 'application record concern' do
     let(:tenant) { Tenant.first }
     let!(:subject) { create(factory_name) }

--- a/services/comm/spec/requests/events_spec.rb
+++ b/services/comm/spec/requests/events_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe 'Events', type: :request do
 
   let(:url) { u('/events') }
   let(:subject) { tenant.switch { create(:event) } }
+  let(:pool) { double(Ros::Cognito::Pool, id: 1) }
+
+  before do
+    allow(Ros::Cognito::Pool).to receive(:where).and_return [pool]
+  end
 
   context 'all' do
     include_context 'jsonapi requests'


### PR DESCRIPTION
[Can't save a campaign without an audience](https://perxtechnologies.atlassian.net/browse/PW-1879)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- cleanup event model class to follow the order in our pattern
- event resource allows pool_id to be passed and transforms that into a "Ros::Cognito::Pool"
- before save ensures a provider is set. This should be updated to match the tenant's default provider.

# How does the implementation addresses the problem

This allows the api to create an event with the proper target set.
