### PR TITLE
Fix association resource helpers

### DIFF
--- a/lib/core/app/models/concerns/association_resource/association_interface.rb
+++ b/lib/core/app/models/concerns/association_resource/association_interface.rb
@@ -11,7 +11,7 @@ module AssociationResource
       model_resource(model)
     end
 
-    def _resource_class
+    def _resource_class(_model)
       class_name.safe_constantize
     end
 

--- a/lib/core/app/models/concerns/association_resource/belongs_to_resource.rb
+++ b/lib/core/app/models/concerns/association_resource/belongs_to_resource.rb
@@ -14,6 +14,10 @@ module AssociationResource
       @polymorphic = polymorphic
     end
 
+    def _resource_class(model)
+      extract_resource_klass(model).safe_constantize
+    end
+
     private
 
     def persisted_resource?(model)
@@ -36,11 +40,11 @@ module AssociationResource
     end
 
     def query_resource(model)
-      @class_name = extract_resource_klass(model)
-      return unless _resource_class
+      resource_klass = _resource_class(model)
+      return unless resource_klass
 
       resource_id = extract_resource_id(model)
-      _resource_class.where(id: resource_id).find.first
+      resource_klass.where(id: resource_id).first
     end
   end
 end

--- a/lib/core/spec/support/helpers/json_api_helper.rb
+++ b/lib/core/spec/support/helpers/json_api_helper.rb
@@ -5,6 +5,7 @@ module JsonApiSpecHelper
     extra_attributes = options.fetch(:extra_attributes, {})
     skip_attributes = options.fetch(:skip_attributes, [])
     method = options.fetch(:method, :get)
+    relations = Array.wrap(options[:relationships])
 
     generic_attributes = %i[id created_at updated_at]
     skip_attributes.append(*generic_attributes)
@@ -14,6 +15,22 @@ module JsonApiSpecHelper
       attributes: object.attributes.except(*skip_attributes.map(&:to_s)).merge(extra_attributes)
     }
     data[:id] = object.id if %i[put patch].include?(method.downcase.to_sym)
+    relation_hash = {}
+    relations.each do |relation|
+      name = relation[:name]
+      type = relation[:type] || name.to_s.pluralize
+      id = relation[:id]
+      next unless id && type
+
+      relation_hash[name] = {
+        data: {
+          type: type,
+          id: id
+        }
+      }
+    end
+
+    data[:relationships] = relation_hash if relation_hash.present?
 
     { data: data }.to_json
   end


### PR DESCRIPTION
- fixed association helpers `@model.resource(:resource_name)`
- added `relationships` support to jsonapi_data rspec helper