### PR TITLE
fixed _resource_class calling without class_name presented

### DIFF
--- a/lib/core/app/models/concerns/association_resource/belongs_to_resource.rb
+++ b/lib/core/app/models/concerns/association_resource/belongs_to_resource.rb
@@ -15,7 +15,10 @@ module AssociationResource
     end
 
     def _resource_class(model)
-      extract_resource_klass(model).safe_constantize
+      resource_klass = extract_resource_klass model
+      return unless resource_klass
+
+      resource_klass.safe_constantize
     end
 
     def query_resource(model)


### PR DESCRIPTION
fixed call of `_resource_class` for `belongs_to_resource` associations if `class_name` not given or not exists