### PR TITLE
[PW-2104] Bump rack-fluentd-logger version

### DIFF
--- a/lib/core/ros-core.gemspec
+++ b/lib/core/ros-core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'zero-rails_openapi', '2.1.0'
   spec.add_dependency 'config', '1.7.1'
   spec.add_dependency 'rack-cors'
-  spec.add_dependency 'rack-fluentd-logger', '0.1.4'
+  spec.add_dependency 'rack-fluentd-logger', '0.1.5'
   spec.add_dependency 'avro_turf', '~> 0.9.0'
   # spec.add_dependency 'ros_sdk', '~> 0.1.0'
 


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Unsuccessful request aren logged by application](https://perxtechnologies.atlassian.net/browse/PW-2104)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

Sergey's PR been merged into [rack-fluentd-logger](https://github.com/mikhailvs/rack-fluentd-logger)
So bump gem version to receive an update

# How does the implementation addresses the problem

Tested that non-2xx requests are logged now and pushed to BQ warehouse
