### PR TITLE
[PW-2098] Profile Service to Fetch cognito users not returning in correct format

### DIFF
--- a/services/cognito/app/policies/tenant_policy.rb
+++ b/services/cognito/app/policies/tenant_policy.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TenantPolicy < Cognito::ApplicationPolicy
+  include Ros::TenantPolicyConcern
+end

--- a/services/cognito/app/policies/user_policy.rb
+++ b/services/cognito/app/policies/user_policy.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
 
 class UserPolicy < Cognito::ApplicationPolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user  = user
+      @scope = scope
+    end
+
+    def resolve
+      if user.cognito_user_id
+        scope.where(id: user.cognito_user_id)
+      else
+        scope.all
+      end
+    end
+  end
 end

--- a/services/cognito/spec/policies/user_policy.rb
+++ b/services/cognito/spec/policies/user_policy.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe UserPolicy, type: :policy do
-  let(:user) { create(:user) }
-end

--- a/services/cognito/spec/policies/user_policy_spec.rb
+++ b/services/cognito/spec/policies/user_policy_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserPolicy, type: :policy do
+  subject { described_class.new(user, User) }
+  let(:iam_user) { create(:iam_user, :with_administrator_policy) }
+  let(:cognito_user_id) { nil }
+  let(:params) { {} }
+  let(:policy_user) { PolicyUser.new(iam_user, cognito_user_id, params) }
+  let(:existing_users) { create_list :user, 2 }
+
+  before do
+    existing_users
+  end
+
+  describe 'Scope' do
+    let(:scope) { Pundit.policy_scope!(policy_user, User) }
+
+    context 'admin iam user' do
+      it 'returns all users' do
+        expect(scope.to_a).to match_array(existing_users)
+      end
+    end
+
+    context 'cognito user' do
+      let(:cognito_user) { existing_users.first }
+      let(:cognito_user_id) { cognito_user.id }
+
+      it 'returns array with only cognito user' do
+        expect(scope.to_a).to match_array([cognito_user])
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Profile Service to Fetch cognito users not returning in correct format](https://perxtechnologies.atlassian.net/browse/PW-2098)

- Created TenantPolicy for cognito user that includes the shared tenant policy from core
- Created UserPolicy that scopes the results based on the cognito user id that the scope has. This is implemented as a temporary solution so the front end can query info about the token owner. With the implementation of policies there would be a specific endpoint to fetch and update info about the token owner.

# How does the implementation addresses the problem

Once this is merged, tenants and users will be scoped in the cognito service based on the context set by the token.
