### PR TITLE
AssociationResource ActiveRecord support

### DIFF
--- a/lib/core/app/models/concerns/association_resource/belongs_to_resource.rb
+++ b/lib/core/app/models/concerns/association_resource/belongs_to_resource.rb
@@ -27,7 +27,11 @@ module AssociationResource
 
       query = yield query if block_given?
       resource_id = extract_resource_id(model)
-      query.where(id: resource_id).find.first
+      if query.ancestors.include? ActiveRecord::Base
+        query.find_by(id: resource_id)
+      else
+        query.where(id: resource_id).find.first
+      end
     end
 
     private

--- a/lib/core/app/models/concerns/association_resource/has_many_resources.rb
+++ b/lib/core/app/models/concerns/association_resource/has_many_resources.rb
@@ -20,7 +20,7 @@ module AssociationResource
       yield query if block_given?
       query = query.where(type_column => model.class.resource_name) if type_column.present?
 
-      query.find
+      query.all
     end
 
     private


### PR DESCRIPTION
Gives ability to `:belongs_to_resource` and `:has_many_resources` which could be polymorphic, to accept `ActiveRecord` models 