### PR TITLE
[PW-920] Search functionality returning incorrect results when searching based on user id.

### DIFF
--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -10,7 +10,7 @@ class UserResource < Cognito::ApplicationResource
     query_by_non_id_attrs = %w[primary_identifier first_name last_name email_address]
                             .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
                             .join(' OR ')
-    filter_fields = value[0].scan(/\D/).empty? ? query_by_id : query_by_non_id_attrs
+    filter_fields = value[0].match(/\D/).nil? ? query_by_id : query_by_non_id_attrs
     records.where(filter_fields)
   }
 

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -6,12 +6,22 @@ class UserResource < Cognito::ApplicationResource
   filter :primary_identifier
 
   filter :query, apply: lambda { |records, value, _options|
-    filter_fields = %w[primary_identifier first_name last_name email_address]
-                    .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
-                    .join(' OR ')
-
+    filter_fields = value[0].scan(/\D/).empty? ? query_id(value[0]) : query_non_id_atrributes(value[0])
     records.where(filter_fields)
   }
 
   has_many :pools
+
+
+  private 
+
+  def query_non_id_atrributes(value)
+    %w[primary_identifier first_name last_name email_address]
+    .map { |field| "#{field} ILIKE '%#{value}%'" }
+    .join(' OR ')
+  end
+
+  def query_id(value)
+    "id IN (#{value})"
+  end
 end

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -12,8 +12,7 @@ class UserResource < Cognito::ApplicationResource
 
   has_many :pools
 
-
-  private 
+  private
 
   def query_non_id_atrributes(value)
     %w[primary_identifier first_name last_name email_address]

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -10,6 +10,7 @@ class UserResource < Cognito::ApplicationResource
     query_by_non_id_attrs = %w[primary_identifier first_name last_name email_address]
                             .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
                             .join(' OR ')
+
     filter_fields = /\D/.match?(value[0]) ? query_by_non_id_attrs : query_by_id
     records.where(filter_fields)
   }

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -10,7 +10,7 @@ class UserResource < Cognito::ApplicationResource
     query_by_non_id_attrs = %w[primary_identifier first_name last_name email_address]
                             .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
                             .join(' OR ')
-    filter_fields = value[0].match(/\D/).nil? ? query_by_id : query_by_non_id_attrs
+    filter_fields = /\D/.match?(value[0]) ? query_by_non_id_attrs : query_by_id
     records.where(filter_fields)
   }
 

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -6,21 +6,13 @@ class UserResource < Cognito::ApplicationResource
   filter :primary_identifier
 
   filter :query, apply: lambda { |records, value, _options|
-    filter_fields = value[0].scan(/\D/).empty? ? query_id(value[0]) : query_non_id_atrributes(value[0])
+    query_by_id = "id IN (#{value[0]})"
+    query_by_non_id_attrs = %w[primary_identifier first_name last_name email_address]
+                            .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
+                            .join(' OR ')
+    filter_fields = value[0].scan(/\D/).empty? ? query_by_id : query_by_non_id_attrs
     records.where(filter_fields)
   }
 
   has_many :pools
-
-  private
-
-  def query_non_id_atrributes(value)
-    %w[primary_identifier first_name last_name email_address]
-      .map { |field| "#{field} ILIKE '%#{value}%'" }
-      .join(' OR ')
-  end
-
-  def query_id(value)
-    "id IN (#{value})"
-  end
 end

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -17,8 +17,8 @@ class UserResource < Cognito::ApplicationResource
 
   def query_non_id_atrributes(value)
     %w[primary_identifier first_name last_name email_address]
-    .map { |field| "#{field} ILIKE '%#{value}%'" }
-    .join(' OR ')
+      .map { |field| "#{field} ILIKE '%#{value}%'" }
+      .join(' OR ')
   end
 
   def query_id(value)

--- a/services/cognito/spec/requests/users_spec.rb
+++ b/services/cognito/spec/requests/users_spec.rb
@@ -37,10 +37,13 @@ RSpec.describe 'users requests', type: :request do
 
       let(:models_count) { rand(1..5) }
       let!(:models) { create_list :user, models_count }
+      let!(:filtered_model) { models.last }
 
       context 'based on ID' do
+        let(:url) { "#{base_url}?filter[query]=#{filtered_model.id}" }
+
         before do
-          get url + "?filter[query]=#{models.last.id}", headers: request_headers
+          get url, headers: request_headers
         end
 
         it 'returns and ok response with the user ID queried' do
@@ -50,11 +53,12 @@ RSpec.describe 'users requests', type: :request do
       end
 
       context 'based on primary_identifier' do
-        let(:model_primary_identifier) { models.last.primary_identifier }
+        let(:model_primary_identifier) { filtered_model.primary_identifier }
         let(:response_count) { models.select { |model| model.primary_identifier == model_primary_identifier }.length }
+        let(:url) { "#{base_url}?filter[query]=#{model_primary_identifier}" }
 
         before do
-          get url + "?filter[query]=#{model_primary_identifier}", headers: request_headers
+          get url, headers: request_headers
         end
 
         it 'returns and ok response with the user attribute queried' do

--- a/services/cognito/spec/requests/users_spec.rb
+++ b/services/cognito/spec/requests/users_spec.rb
@@ -31,6 +31,38 @@ RSpec.describe 'users requests', type: :request do
         expect_json_sizes('data', models_count)
       end
     end
+
+    context 'perform query' do
+      include_context 'authorized user'
+
+      let(:models_count) { rand(1..5) }
+      let!(:models) { create_list :user, models_count }
+
+      context 'based on ID' do
+        before do
+          get url + "?filter[query]=#{models.last.id}", headers: request_headers
+        end
+
+        it 'returns and ok response with the user ID queried' do
+          expect(response).to have_http_status(:ok)
+          expect_json_sizes('data', 1)
+        end
+      end
+
+      context 'based on primary_identifier' do
+        let(:model_primary_identifier) { models.last.primary_identifier }
+        let(:response_count) { models.select { |model| model.primary_identifier == model_primary_identifier }.length }
+
+        before do
+          get url + "?filter[query]=#{model_primary_identifier}", headers: request_headers
+        end
+
+        it 'returns and ok response with the user attribute queried' do
+          expect(response).to have_http_status(:ok)
+          expect_json_sizes('data', response_count)
+        end
+      end
+    end
   end
 
   describe 'GET show' do


### PR DESCRIPTION
[Search functionality returning incorrect results when searching based on user id](https://perxtechnologies.atlassian.net/browse/PW-1779?atlOrigin=eyJpIjoiODI0MmM0MjE5Mjc5NDgyN2FmMGY3M2VjY2EyNjVkNTEiLCJwIjoiaiJ9)

- Perform a check to see if query string is digits only, and if yes, query by ID. Else, perform a query based on other attributes such as primary_identifier, first_name etc.

- This should return more accurate results and removes list of redundant info when query by ID.