### PR TITLE
[Chore] Use GitHub actions for rubocop lint

### DIFF
--- a/.github/workflows/lint_rubocop.yml
+++ b/.github/workflows/lint_rubocop.yml
@@ -1,0 +1,19 @@
+name: Rubocop Lint
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.3
+    - name: Install perx-rubocop and run lint
+      run: |
+        gem install perx-rubocop --pre
+        rubocop

--- a/.github/workflows/lint_rubocop.yml
+++ b/.github/workflows/lint_rubocop.yml
@@ -13,7 +13,9 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.3
-    - name: Install perx-rubocop and run lint
+    - name: Install perx-rubocop
       run: |
         gem install perx-rubocop --pre
+    - name: Run Rubocop Lint
+      run: |
         rubocop

--- a/services/organization/spec/models/org_spec.rb
+++ b/services/organization/spec/models/org_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Org, type: :model do
   include_examples 'application record concern' do
     let(:tenant) { Tenant.first }
-    let!(:subject) { create(factory_name) }
+    let!(:subject) { FactoryBot.create(factory_name) }
   end
 
   describe 'associations' do

--- a/services/organization/spec/models/org_spec.rb
+++ b/services/organization/spec/models/org_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Org, type: :model do
   include_examples 'application record concern' do
     let(:tenant) { Tenant.first }
-    let!(:subject) { FactoryBot.create(factory_name) }
+    let!(:subject) { create(factory_name) }
   end
 
   describe 'associations' do


### PR DESCRIPTION
- N/a

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Created GitHub workflow to run rubocop lint on Push

# How does the implementation addresses the problem

1. This allows us to have the rubocop listing separated from the CircleCI running the tests.
2. Currently Core and SDK because they are 'loaded as gems' they are not being lint while running `ros be test` because this depends on the service to be built.
