### PR TITLE
[PW-1779] Search functionality returning incorrect results when searching based on user id.

### DIFF
--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -6,7 +6,7 @@ class UserResource < Cognito::ApplicationResource
   filter :primary_identifier
 
   filter :query, apply: lambda { |records, value, _options|
-    query_by_id = "id IN (#{value[0]})"
+    query_by_id = "users.id IN (#{value[0]})"
     query_by_non_id_attrs = %w[primary_identifier first_name last_name email_address]
                             .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
                             .join(' OR ')

--- a/services/cognito/spec/requests/users_spec.rb
+++ b/services/cognito/spec/requests/users_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe 'users requests', type: :request do
           end
         end
 
+        context 'matching query with include pools' do
+          let(:url) { "#{base_url}?filter[query]=#{random_model.id}&include=pools" }
+
+          before do
+            get url, headers: request_headers
+          end
+
+          it 'returns and ok response with the user ID queried' do
+            expect(response).to have_http_status(:ok)
+            expect_json_sizes('data', 1)
+            expect_json('data.0', id: random_model.id.to_s)
+          end
+        end
+
         context 'non-matching query' do
           let(:url) { "#{base_url}?filter[query]=#{random_id}" }
 


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Search functionality returning incorrect results when searching based on user id.](https://perxtechnologies.atlassian.net/browse/PW-1779)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

Specified table in SQL query when querying for an ID.

# How does the implementation addresses the problem

This address the ambiguous column error raised because current SQL query only passes in ID, without specifying the table to perform the query on.