### PR TITLE
[PW-1877] Audience List search filter don't work

### DIFF
--- a/services/cognito/app/resources/pool_resource.rb
+++ b/services/cognito/app/resources/pool_resource.rb
@@ -4,7 +4,13 @@ class PoolResource < Cognito::ApplicationResource
   attributes :name, :properties
   has_many :users
 
-  filter :name, apply: lambda { |records, value, _options|
-    records.where('name ILIKE ?', "%#{value[0]}%")
+  filter :query, apply: lambda { |records, value, _options|
+    query_by_id = "pools.id IN (#{value[0]})"
+    query_by_non_id_attrs = %w[name]
+                            .map { |field| "#{field} ILIKE '%#{value[0]}%'" }
+                            .join(' OR ')
+
+    filter_fields = /\D/.match?(value[0]) ? query_by_non_id_attrs : query_by_id
+    records.where(filter_fields)
   }
 end

--- a/services/cognito/app/resources/pool_resource.rb
+++ b/services/cognito/app/resources/pool_resource.rb
@@ -3,4 +3,8 @@
 class PoolResource < Cognito::ApplicationResource
   attributes :name, :properties
   has_many :users
+
+  filter :name, apply: lambda { |records, value, _options|
+    records.where('name ILIKE ?', "%#{value[0]}%")
+  }
 end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -46,58 +46,105 @@ RSpec.describe 'pools requests', type: :request do
       end
     end
 
-    context 'filter names' do
+    context 'perform query' do
       include_context 'authorized user'
 
       let!(:pool_name) { 'Pool-One'}
       let!(:model) { create(:pool, name: pool_name) }
       let!(:user)  { create(:user) }
       let!(:user_pool) { create(:user_pool, pool: model, user: user)}
+      let!(:random_id) { model.id + 10 }
      
       before do
         get url, headers: request_headers
       end
 
-      context 'with match found' do
-        context 'without users included' do
-          let(:url) { "#{base_url}?filter[name]=#{pool_name}" }
+      context 'based on ID' do
+        context 'with match found' do
+          context 'without users included' do
+            let(:url) { "#{base_url}?filter[query]=#{model.id}" }
 
-          it 'returns successful response' do
-            expect(response).to have_http_status(:ok)
-            expect_json_sizes('data', 1)
-            expect_json('included', nil)
-            expect_json('data.0.attributes.name', pool_name)
+            it 'returns successful response' do
+              expect(response).to have_http_status(:ok)
+              expect_json_sizes('data', 1)
+              expect_json('included', nil)
+              expect_json('data.0.id', model.id.to_s)
+            end
           end
+
+          context 'with users included' do
+            let(:url) { "#{base_url}?include=users&filter[query]=#{model.id}" }
+
+            it 'returns successful response' do
+              expect(response).to have_http_status(:ok)
+              expect_json_sizes('data', 1)
+              expect_json_types('included', :array)
+              expect_json('data.0.id', model.id.to_s)
+            end
+          end 
         end
 
-        context 'with users included' do
-          let(:url) { "#{base_url}?include=users&filter[name]=#{pool_name}" }
+        context 'with no match found' do 
+          context 'without users included' do
+            let(:url) { "#{base_url}?filter[query]=#{random_id}" }
 
-          it 'returns successful response' do
-            expect(response).to have_http_status(:ok)
-            expect_json_sizes('data', 1)
-            expect_json_types('included', :array)
-            expect_json('data.0.attributes.name', pool_name)
+            it 'returns successful response with zero result' do
+              expect_json_sizes('data', 0)
+            end
           end
-        end 
+
+          context 'with users included' do
+            let(:url) { "#{base_url}?include=users&filter[query]=#{random_id}" }
+
+            it 'returns successful response with zero result' do
+              expect_json_sizes('data', 0)
+            end
+          end 
+        end
       end
 
-      context 'with no match found' do 
-        context 'without users included' do
-          let(:url) { "#{base_url}?filter[name]=some_random_name" }
+      context 'based on name' do
+        context 'with match found' do
+          context 'without users included' do
+            let(:url) { "#{base_url}?filter[query]=#{pool_name}" }
 
-          it 'returns successful response with zero result' do
-            expect_json_sizes('data', 0)
+            it 'returns successful response' do
+              expect(response).to have_http_status(:ok)
+              expect_json_sizes('data', 1)
+              expect_json('included', nil)
+              expect_json('data.0.attributes.name', pool_name)
+            end
           end
+
+          context 'with users included' do
+            let(:url) { "#{base_url}?include=users&filter[query]=#{pool_name}" }
+
+            it 'returns successful response' do
+              expect(response).to have_http_status(:ok)
+              expect_json_sizes('data', 1)
+              expect_json_types('included', :array)
+              expect_json('data.0.attributes.name', pool_name)
+            end
+          end 
         end
 
-        context 'with users included' do
-          let(:url) { "#{base_url}?include=users&filter[name]=kiwi" }
+        context 'with no match found' do 
+          context 'without users included' do
+            let(:url) { "#{base_url}?filter[query]=some_random_name" }
 
-          it 'returns successful response with zero result' do
-            expect_json_sizes('data', 0)
+            it 'returns successful response with zero result' do
+              expect_json_sizes('data', 0)
+            end
           end
-        end 
+
+          context 'with users included' do
+            let(:url) { "#{base_url}?include=users&filter[query]=kiwi" }
+
+            it 'returns successful response with zero result' do
+              expect_json_sizes('data', 0)
+            end
+          end 
+        end
       end
     end
   end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'pools requests', type: :request do
+  include_context 'jsonapi requests'
+
+  let(:tenant) { Tenant.first }
+  let(:mock) { true }
+  let(:base_url) { u('/pools') }
+  let(:url) { base_url }
+
+  describe 'GET index' do
+    context 'Unauthenticated user' do
+      include_context 'unauthorized user'
+      include_examples 'unauthenticated get'
+    end
+
+    context 'authenticated user' do
+      include_context 'authorized user'
+
+      let!(:model) { create(:pool) }
+      let!(:user)  { create(:user) }
+      let!(:user_pool) { create(:user_pool, pool: model, user: user)}
+     
+      before do
+        get url, headers: request_headers
+      end
+
+      context 'without users included' do
+        it 'returns successful response' do
+          expect(response).to have_http_status(:ok)
+          expect_json_sizes('data', 1)
+          expect_json('included', nil)
+        end
+      end
+
+      context 'with users included' do
+        let(:url) { "#{base_url}?include=users" }
+
+        it 'returns successful response' do
+          expect(response).to have_http_status(:ok)
+          expect_json_sizes('data', 1)
+          expect_json_types('included', :array)
+        end
+      end
+    end
+  end
+end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'pools requests', type: :request do
       let!(:model) { create(:pool) }
       let!(:user)  { create(:user) }
       let!(:user_pool) { create(:user_pool, pool: model, user: user) }
-      
+
       before do
         get url, headers: request_headers
       end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'pools requests', type: :request do
       let!(:model) { create(:pool) }
       let!(:user)  { create(:user) }
       let!(:user_pool) { create(:user_pool, pool: model, user: user) }
-     
+      
       before do
         get url, headers: request_headers
       end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'pools requests', type: :request do
 
       let!(:model) { create(:pool) }
       let!(:user)  { create(:user) }
-      let!(:user_pool) { create(:user_pool, pool: model, user: user)}
+      let!(:user_pool) { create(:user_pool, pool: model, user: user) }
      
       before do
         get url, headers: request_headers

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe 'pools requests', type: :request do
     context 'perform query' do
       include_context 'authorized user'
 
-      let!(:pool_name) { 'Pool-One'}
+      let!(:pool_name) { 'Pool-One' }
       let!(:model) { create(:pool, name: pool_name) }
       let!(:user)  { create(:user) }
-      let!(:user_pool) { create(:user_pool, pool: model, user: user)}
+      let!(:user_pool) { create(:user_pool, pool: model, user: user) }
       let!(:random_id) { model.id + 10 }
-     
+
       before do
         get url, headers: request_headers
       end
@@ -81,10 +81,10 @@ RSpec.describe 'pools requests', type: :request do
               expect_json_types('included', :array)
               expect_json('data.0.id', model.id.to_s)
             end
-          end 
+          end
         end
 
-        context 'with no match found' do 
+        context 'with no match found' do
           context 'without users included' do
             let(:url) { "#{base_url}?filter[query]=#{random_id}" }
 
@@ -99,7 +99,7 @@ RSpec.describe 'pools requests', type: :request do
             it 'returns successful response with zero result' do
               expect_json_sizes('data', 0)
             end
-          end 
+          end
         end
       end
 
@@ -125,10 +125,10 @@ RSpec.describe 'pools requests', type: :request do
               expect_json_types('included', :array)
               expect_json('data.0.attributes.name', pool_name)
             end
-          end 
+          end
         end
 
-        context 'with no match found' do 
+        context 'with no match found' do
           context 'without users included' do
             let(:url) { "#{base_url}?filter[query]=some_random_name" }
 
@@ -143,7 +143,7 @@ RSpec.describe 'pools requests', type: :request do
             it 'returns successful response with zero result' do
               expect_json_sizes('data', 0)
             end
-          end 
+          end
         end
       end
     end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Audience List search filter don't work](https://perxtechnologies.atlassian.net/browse/PW-1877)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Handles query by name and ID, when filter[query] sent to endpoint

# How does the implementation addresses the problem

This allows audience list to be filtered by ID and name. Currently only ID filtering works.