### PR TITLE
[PW-2459] Add sentry gem to our backend and configure it properly

### DIFF
--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -9,7 +9,7 @@ module Ros
 
       before_action :authenticate_it!
       before_action :set_tenant_context
-      before_action :set_raven_context, if: -> { Settings.credentials.sentry_dsn }
+      before_action :set_raven_context, if: -> { ENV['SENTRY_DSN'] }
       after_action :set_headers!
 
       def authenticate_it!

--- a/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
+++ b/lib/core/app/controllers/concerns/ros/application_controller_concern.rb
@@ -7,9 +7,9 @@ module Ros
     included do
       include JSONAPI::ActsAsResourceController
 
-      before_action :set_raven_context, if: -> { Settings.credentials.sentry_dsn }
       before_action :authenticate_it!
       before_action :set_tenant_context
+      before_action :set_raven_context, if: -> { Settings.credentials.sentry_dsn }
       after_action :set_headers!
 
       def authenticate_it!

--- a/lib/core/lib/ros/core/engine.rb
+++ b/lib/core/lib/ros/core/engine.rb
@@ -182,6 +182,7 @@ module Ros
       # Configure any error reporting services if their credential has been set
       # For now, only sentry.io is supported
       initializer 'ros_core.configure_error_reporting' do |_app|
+        binding.pry
         # export PLATFORM__CREDENTIALS__SENTRY_DSN=url
         if Settings.dig(:credentials, :sentry_dsn)
           require 'sentry-raven'

--- a/lib/core/lib/ros/core/engine.rb
+++ b/lib/core/lib/ros/core/engine.rb
@@ -182,12 +182,11 @@ module Ros
       # Configure any error reporting services if their credential has been set
       # For now, only sentry.io is supported
       initializer 'ros_core.configure_error_reporting' do |_app|
-        binding.pry
         # export PLATFORM__CREDENTIALS__SENTRY_DSN=url
-        if Settings.dig(:credentials, :sentry_dsn)
+        if ENV['SENTRY_DSN']
           require 'sentry-raven'
           Raven.configure do |config|
-            config.dsn = Settings.credentials.sentry_dsn
+            config.dsn = ENV['SENTRY_DSN']
           end
         end
       end


### PR DESCRIPTION
[Add sentry gem to our backend and configure it properly](https://perxtechnologies.atlassian.net/browse/PW-2459)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Checking for Sentry Env var set to require it in engine init.
- Setting context if sentry env set

# How does the implementation addresses the problem

This enables Sentry in our services if the env var is defined
