### PR TITLE
[PW-2433] Make sure that querying cognito tenants with root token returns the full list of tenants

### DIFF
--- a/lib/core/app/models/policy_user.rb
+++ b/lib/core/app/models/policy_user.rb
@@ -19,7 +19,7 @@ class PolicyUser
   end
 
   def root?
-    @iam_user.class.name.eql? 'Root'
+    ['Root', 'Ros::IAM::Root'].include? @iam_user.class.name
   end
 
   def schema_name

--- a/lib/core/app/policies/concerns/ros/tenant_policy_concern.rb
+++ b/lib/core/app/policies/concerns/ros/tenant_policy_concern.rb
@@ -14,8 +14,12 @@ module Ros
         end
 
         def resolve
-          current_tenant = Tenant.find_by(schema_name: user.schema_name)
-          scope.where(id: current_tenant.id)
+          if user.root?
+            scope.all
+          else
+            current_tenant = Tenant.find_by(schema_name: user.schema_name)
+            scope.where(id: current_tenant.id)
+          end
         end
       end
     end

--- a/lib/core/lib/ros/tenant_middleware.rb
+++ b/lib/core/lib/ros/tenant_middleware.rb
@@ -52,6 +52,8 @@ module Ros
     private
 
     def parse_auth_type_and_token
+      return if auth_string.blank?
+
       @auth_type, @token = auth_string.split(' ')
       @auth_type.downcase!
     end

--- a/services/iam/app/controllers/concerns/is_tenant_scoped.rb
+++ b/services/iam/app/controllers/concerns/is_tenant_scoped.rb
@@ -13,7 +13,7 @@ module IsTenantScoped
     # this is not a dynamically created method but defined in our tenant concern
     # rubocop:disable Rails/DynamicFindBy
     Tenant.find_by_schema_or_alias(params_[key])&.schema_name ||
-      Apartment::Tenant.current
+      'public'
     # rubocop:enable Rails/DynamicFindBy
   end
 

--- a/services/iam/app/controllers/credentials_controller.rb
+++ b/services/iam/app/controllers/credentials_controller.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 
 class CredentialsController < Iam::ApplicationController
+  def index
+    # NOTE: For us to identify the tenant schema in the tenant_middleware,
+    # while using a Basic Token it triggers a remote call to the credentials
+    # index trying to filter the credentials using the access_key. The
+    # credentials for the root are currently stored in the public schema,
+    # therefore we need to switch the context to public schema so we can
+    # identify the root user.
+    if context[:user].root?
+      Apartment::Tenant.switch 'public' do
+        return super
+      end
+    end
+
+    super
+  end
 end

--- a/services/iam/app/controllers/iam/passwords_controller.rb
+++ b/services/iam/app/controllers/iam/passwords_controller.rb
@@ -10,6 +10,8 @@ module Iam
 
     # POST /resource/password
     def create
+      binding.pry
+
       Apartment::Tenant.switch tenant_schema(password_params) do
         return super unless find_user!
 

--- a/services/iam/app/controllers/iam/passwords_controller.rb
+++ b/services/iam/app/controllers/iam/passwords_controller.rb
@@ -10,8 +10,6 @@ module Iam
 
     # POST /resource/password
     def create
-      binding.pry
-
       Apartment::Tenant.switch tenant_schema(password_params) do
         return super unless find_user!
 

--- a/services/iam/db/seeds/development/users.seeds.rb
+++ b/services/iam/db/seeds/development/users.seeds.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# ubocop:disable Metrics/BlockLength
 after 'development:tenants' do
   Tenant.all.each do |tenant|
     next if tenant.id.eql? 1
@@ -64,4 +63,3 @@ after 'development:tenants' do
   STDOUT.puts 'Credentials are next:'
   STDOUT.puts File.read("#{Ros.host_tmp_dir}/credentials.json")
 end
-# ubocop:enable Metrics/BlockLength

--- a/services/iam/spec/requests/roots/authentication_spec.rb
+++ b/services/iam/spec/requests/roots/authentication_spec.rb
@@ -5,16 +5,21 @@ require 'rails_helper'
 RSpec.describe 'Root Authentication', type: :request do
   context :create do
     let(:url) { '/roots/sign_in' }
-    let(:root) { create(:root, email: 'test@email.com', password: '123456') }
+    let!(:root) do
+      Apartment::Tenant.switch 'public' do
+        create(:root, email: 'test@email.com', password: '123456')
+      end
+    end
     let(:valid_attributes) { { email: root.email, password: '123456' } }
     let(:invalid_attributes) { { email: root.email, password: 'fake' } }
 
-    before(:each) do
+    before do
       post url, params: params, as: :json
     end
 
     context 'with invalid credentials' do
       let(:params) { { data: { attributes: invalid_attributes } } }
+
       it 'returns unauthorized status' do
         expect(response.status).to eq 401
       end
@@ -22,6 +27,7 @@ RSpec.describe 'Root Authentication', type: :request do
 
     context 'with valid credentials' do
       let(:params) { { data: { attributes: valid_attributes } } }
+
       xit 'returns success status' do
         expect(response.status).to eq 200
       end

--- a/services/iam/spec/requests/users/confirmation_spec.rb
+++ b/services/iam/spec/requests/users/confirmation_spec.rb
@@ -35,19 +35,32 @@ RSpec.describe 'Account confirmation', type: :request do
     include_context 'jsonapi requests'
 
     context 'should trigger confirmation email' do
-      it 'should fail when no tenant is specified' do
-        post url, params: { data: { attributes: { username: user.username, account_id: nil } } }, headers: headers, as: :json
-        expect(response).to_not be_successful
+      before do
+        post url, params: params, headers: headers, as: :json
       end
 
-      it 'should fail when no user is specified' do
-        post url, params: { data: { attributes: { username: nil, account_id: tenant.account_id } } }, headers: headers, as: :json
-        expect(response).to_not be_successful
+      context 'when no tenant is specified' do
+        let(:params) { { data: { attributes: { username: user.username, account_id: nil } } } }
+
+        it 'should fail' do
+          expect(response).to_not be_successful
+        end
       end
 
-      it 'should allow performing an account confirmation without authentication' do
-        post url, params: valid_params, headers: headers, as: :json
-        expect(response).to be_successful
+      context 'when no used is specified' do
+        let(:params) { { data: { attributes: { username: nil, account_id: tenant.account_id } } } }
+
+        it 'should fail when no user is specified' do
+          expect(response).to_not be_successful
+        end
+      end
+
+      context 'with the right params and no auth headers' do
+        let(:params) { valid_params }
+
+        it 'should allow performing an account confirmation without authentication' do
+          expect(response).to be_successful
+        end
       end
     end
 

--- a/services/iam/spec/requests/users/password_spec.rb
+++ b/services/iam/spec/requests/users/password_spec.rb
@@ -114,12 +114,10 @@ RSpec.describe 'Password management', type: :request do
       let(:headers) { { 'Content-Type' => 'application/vnd.api+json' } }
 
       before do
-        puts warning
         post url, params: params, headers: headers, as: :json
       end
 
       context 'when no user is specified' do
-        let!(:warning) { '' }
         let(:params) { { data: { attributes: { username: nil, account_id: tenant.account_id } } } }
 
         it 'should fail' do
@@ -128,17 +126,14 @@ RSpec.describe 'Password management', type: :request do
       end
 
       context 'when no tenant is specified' do
-        let!(:warning) { 'BANANAS!!!!!!!!!!!!!!!!' }
         let(:params) { { data: { attributes: { username: user.username, account_id: nil } } } }
 
         it 'should fail when no tenant is specified' do
-          binding.pry
           expect(response).to_not be_successful
         end
       end
 
       context 'with the right params and no auth headers' do
-        let!(:warning) { '' }
         let(:params) { password_reset_params }
 
         it 'should allow performing a password reset/recovery' do

--- a/services/iam/spec/requests/users/password_spec.rb
+++ b/services/iam/spec/requests/users/password_spec.rb
@@ -112,21 +112,38 @@ RSpec.describe 'Password management', type: :request do
 
     context 'triggering password recovery email' do
       let(:headers) { { 'Content-Type' => 'application/vnd.api+json' } }
-      let(:params) { password_reset_params }
 
-      it 'should fail when no user is specified' do
-        post url, params: { data: { attributes: { username: nil, account_id: tenant.account_id } } }, headers: headers, as: :json
-        expect(response).to_not be_successful
-      end
-
-      it 'should fail when no tenant is specified' do
-        post url, params: { data: { attributes: { username: user.username, account_id: nil } } }, headers: headers, as: :json
-        expect(response).to_not be_successful
-      end
-
-      it 'should allow performing a password reset/recovery without authentication' do
+      before do
+        puts warning
         post url, params: params, headers: headers, as: :json
-        expect(response).to be_successful
+      end
+
+      context 'when no user is specified' do
+        let!(:warning) { '' }
+        let(:params) { { data: { attributes: { username: nil, account_id: tenant.account_id } } } }
+
+        it 'should fail' do
+          expect(response).to_not be_successful
+        end
+      end
+
+      context 'when no tenant is specified' do
+        let!(:warning) { 'BANANAS!!!!!!!!!!!!!!!!' }
+        let(:params) { { data: { attributes: { username: user.username, account_id: nil } } } }
+
+        it 'should fail when no tenant is specified' do
+          binding.pry
+          expect(response).to_not be_successful
+        end
+      end
+
+      context 'with the right params and no auth headers' do
+        let!(:warning) { '' }
+        let(:params) { password_reset_params }
+
+        it 'should allow performing a password reset/recovery' do
+          expect(response).to be_successful
+        end
       end
     end
   end


### PR DESCRIPTION
[Make sure that querying cognito tenants with root token returns the full list of tenants](https://perxtechnologies.atlassian.net/browse/PW-2433)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Updated policy user to check if the class is either IAM root or service discovery root user to determine if the requesting user is a root.
- Update the tenant policy concern to not scope the tenants if the user is root.
- refactored tenant middleware
- Updated iam credentials controller for index to switch the tenant back to public if the requesting user is a root

# How does the implementation addresses the problem

After merging this, we are able to request a list of current tenants in any service using a root token. All the pre-existing behaviour should remain the same.
