### PR TITLE
[PW-2612] Birthday worker

### DIFF
--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -2,8 +2,8 @@
 
 class UserResource < Cognito::ApplicationResource
   attributes :title, :first_name, :last_name, :phone_number, :email_address,
-             :primary_identifier, :properties, :anonymous
-  filter :primary_identifier
+             :primary_identifier, :properties, :anonymous, :birthday
+  filters :primary_identifier, :birthday
 
   filter :query, apply: lambda { |records, value, _options|
     query_by_non_id_attrs = %w[primary_identifier first_name last_name phone_number email_address]

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -3,7 +3,7 @@
 class UserResource < Cognito::ApplicationResource
   attributes :title, :first_name, :last_name, :phone_number, :email_address,
              :primary_identifier, :properties, :anonymous, :birthday
-  filters :primary_identifier, :birthday
+  filter :primary_identifier
 
   filter :query, apply: lambda { |records, value, _options|
     query_by_non_id_attrs = %w[primary_identifier first_name last_name phone_number email_address]
@@ -13,6 +13,14 @@ class UserResource < Cognito::ApplicationResource
     results = records.where(query_by_non_id_attrs, non_id_query: "%#{value[0]}%")
     results = results.or(records.where(id: value[0])) if /^(\d)+$/.match?(value[0])
     results
+  }
+
+  filter :birth_day, apply: lambda { |records, value, _options|
+    records.where("TO_CHAR(birthday, 'DD-MM') = TO_CHAR(DATE(?), 'DD-MM')", value[0])
+  }
+
+  filter :birth_month, apply: lambda { |records, value, _options|
+    records.where("TO_CHAR(birthday, 'MM') = TO_CHAR(DATE(?), 'MM')", value[0])
   }
 
   has_many :pools

--- a/services/cognito/db/migrate/20191129055605_add_birthday_to_user.rb
+++ b/services/cognito/db/migrate/20191129055605_add_birthday_to_user.rb
@@ -1,0 +1,5 @@
+class AddBirthdayToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :birthday, :date
+  end
+end

--- a/services/cognito/doc/schemas/cloud_events/cognito/metabase_card.avsc
+++ b/services/cognito/doc/schemas/cloud_events/cognito/metabase_card.avsc
@@ -8,19 +8,11 @@
     },
     {
       "name": "card_id",
-      "type": [
-        "null",
-        "int"
-      ],
-      "default": null
+      "type": "int"
     },
     {
       "name": "identifier",
-      "type": [
-        "null",
-        "string"
-      ],
-      "default": null
+      "type": "string"
     },
     {
       "name": "created_at",

--- a/services/cognito/doc/schemas/cloud_events/cognito/metabase_card.avsc
+++ b/services/cognito/doc/schemas/cloud_events/cognito/metabase_card.avsc
@@ -8,11 +8,19 @@
     },
     {
       "name": "card_id",
-      "type": "int"
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
     },
     {
       "name": "identifier",
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "name": "created_at",

--- a/services/cognito/doc/schemas/cloud_events/cognito/user.avsc
+++ b/services/cognito/doc/schemas/cloud_events/cognito/user.avsc
@@ -93,6 +93,14 @@
       "default": null
     },
     {
+      "name": "birthday",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
       "name": "urn",
       "type": [
         "null",

--- a/services/cognito/spec/dummy/db/schema.rb
+++ b/services/cognito/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_26_011832) do
+ActiveRecord::Schema.define(version: 2019_11_29_055605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2019_11_26_011832) do
     t.jsonb "properties"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "birthday"
     t.index ["primary_identifier"], name: "index_users_on_primary_identifier", unique: true
   end
 

--- a/services/cognito/spec/requests/users_spec.rb
+++ b/services/cognito/spec/requests/users_spec.rb
@@ -131,6 +131,37 @@ RSpec.describe 'users requests', type: :request do
         end
       end
     end
+
+    context 'birthday filter' do
+      include_context 'authorized user'
+
+      let(:url) { "#{base_url}?filter[#{filter}]=#{Time.zone.today}" }
+
+      let!(:birthday_user) { create(:user, birthday: Time.zone.today) }
+      let!(:non_birthday_user) { create(:user, birthday: Time.zone.today - 1.month) }
+
+      context 'birth_day' do
+        let(:filter) { 'birth_day' }
+
+        it 'returns correctly filtered results' do
+          get url, headers: request_headers
+          expect(response).to be_successful
+          expect_json_sizes('data', 1)
+          expect_json('data.0', id: birthday_user.id.to_s)
+        end
+      end
+
+      context 'birth_month' do
+        let(:filter) { 'birth_month' }
+
+        it 'returns correctly filtered results' do
+          get url, headers: request_headers
+          expect(response).to be_successful
+          expect_json_sizes('data', 1)
+          expect_json('data.0', id: birthday_user.id.to_s)
+        end
+      end
+    end
   end
 
   describe 'GET show' do


### PR DESCRIPTION
# Refer to the JIRA issue id if any. Include the link to the issue. E.g:
[Implement a birthday worker](https://perxtechnologies.atlassian.net/browse/PW-2612)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
- Add `birthday` column to cognito user
- Create `birth_day` and `birth_month` filters to cognito user resource

# How does the implementation addresses the problem

After merging this, we will be able to save birthday for cognito user and filter users by their birth day or month using any date or timestamp:
`?filter[birth_day]=2019-12-01T05:22:08` or `?filter[birth_day]=2019-12-01` matches to `1990-12-01`, `1983-12-01` etc.

`?filter[birth_month]=2019-12-06T05:22:08` or `?filter[birth_month]=2019-12-31` matches to `1991-12-21`, `2001-12-04` etc.