### PR TITLE
[PW-2434] define how a root user should create an app token for a specific tenant

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,4 @@ inherit_from: .rubocop_todo.yml
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_schema_or_alias
+    - find_by_urn

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_gem:
     - default.yml
 
 inherit_from: .rubocop_todo.yml
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_schema_or_alias

--- a/lib/core/app/models/concerns/ros/urn_concern.rb
+++ b/lib/core/app/models/concerns/ros/urn_concern.rb
@@ -6,21 +6,31 @@ module Ros
 
     class_methods do
       # urn:partition:service:region:account_id:resource_type
-      def to_urn; "#{urn_base}:#{account_id}:#{name.underscore}" end
+      def to_urn
+        "#{urn_base}:#{account_id}:#{name.underscore}"
+      end
 
       # Universal Resource Name (URNs) and Service Namespaces
       # urn:partition:service:region
-      def urn_base; "urn:#{Settings.partition_name}:#{Settings.service.name}:#{Settings.region}" end
+      def urn_base
+        "urn:#{Settings.partition_name}:#{Settings.service.name}:#{Settings.region}"
+      end
 
-      def find_by_urn(value); find_by(urn_id => value) end
+      def find_by_urn(value)
+        find_by(urn_id => value)
+      end
 
       # NOTE: Override in model to provide a custom id
-      def urn_id; :id end
+      def urn_id
+        :id
+      end
     end
 
     included do
       # urn:partition:service:region:account_id:resource_type/id
-      def to_urn; "#{self.class.to_urn}/#{send(self.class.urn_id)}" end
+      def to_urn
+        "#{self.class.to_urn}/#{send(self.class.urn_id)}"
+      end
 
       def urn_match?(urn_to_compare)
         params = %i[txt partition_name service_name region account_id resource]

--- a/lib/core/lib/ros/api_token_strategy.rb
+++ b/lib/core/lib/ros/api_token_strategy.rb
@@ -2,23 +2,33 @@
 
 module Ros
   class ApiTokenStrategy < Warden::Strategies::Base
-    attr_accessor :auth_string, :auth_type, :token, :access_key_id, :secret_access_key, :access_key
+    def auth_string
+      @auth_string ||= env['HTTP_AUTHORIZATION']
+    end
 
-    # rubocop:disable Lint/DuplicateMethods
-    def auth_string; @auth_string ||= env['HTTP_AUTHORIZATION'] end
+    def auth_type
+      @auth_type ||= auth_string.split.first.downcase
+    end
 
-    def auth_type; @auth_type ||= auth_string.split.first.downcase end
+    def token
+      @token ||= auth_string&.split&.last
+    end
 
-    def token; @token ||= auth_string&.split&.last end
+    def access_key_id
+      @access_key_id ||= token.split(':').first
+    end
 
-    def access_key_id; @access_key_id ||= token.split(':').first end
+    def access_key
+      @access_key ||= Ros::AccessKey.decode(access_key_id)
+    end
 
-    def access_key; @access_key ||= Ros::AccessKey.decode(access_key_id) end
+    def secret_access_key
+      @secret_access_key ||= token.split(':').last
+    end
 
-    def secret_access_key; @secret_access_key ||= token.split(':').last end
-    # rubocop:enable Lint/DuplicateMethods
-
-    def valid?; token.present? end
+    def valid?
+      token.present?
+    end
 
     def authenticate!
       user = send("authenticate_#{auth_type}") if auth_type.in? %w[basic bearer]
@@ -48,9 +58,7 @@ module Ros
       if jwt.claims.key?('user')
         "Ros::IAM::#{urn.model_name}".constantize.new(JSON.parse(jwt.claims['user']))
       else
-        # rubocop:disable Rails/DynamicFindBy
-        "Ros::IAM::#{urn.model_name}".constantize.find_by_urn(urn.resource_id).first
-        # rubocop:enable Rails/DynamicFindBy
+        "Ros::IAM::#{urn.model_name}".constantize.find_by_urn(urn.resource_id)
       end
 
     # NOTE: Swallow the auth error and return nil which causes user to be nil, which cuases FailureApp to be invoked

--- a/lib/core/lib/ros/urn.rb
+++ b/lib/core/lib/ros/urn.rb
@@ -54,9 +54,7 @@ module Ros
 
     def model; model_name.constantize end
 
-    # rubocop:disable Rails/DynamicFindBy
     def instance; model.find_by_urn(resource_id) end
-    # rubocop:enable Rails/DynamicFindBy
 
     def to_s; to_a.join(':') end
   end

--- a/services/iam/app/controllers/concerns/is_tenant_scoped.rb
+++ b/services/iam/app/controllers/concerns/is_tenant_scoped.rb
@@ -11,10 +11,8 @@ module IsTenantScoped
     params_ = HashWithIndifferentAccess.new(params)
 
     # this is not a dynamically created method but defined in our tenant concern
-    # rubocop:disable Rails/DynamicFindBy
     Tenant.find_by_schema_or_alias(params_[key])&.schema_name ||
       Apartment::Tenant.current
-    # rubocop:enable Rails/DynamicFindBy
   end
 
   def user_resource

--- a/services/iam/app/controllers/credentials_controller.rb
+++ b/services/iam/app/controllers/credentials_controller.rb
@@ -1,29 +1,23 @@
 # frozen_string_literal: true
 
 class CredentialsController < Iam::ApplicationController
-  before_action :validate_platform_owner, only: [:blackcomb]
-
   # TODO: Remove this once we support registration of callbacks
   def blackcomb
-    tenant = Tenant.find_by_schema_or_alias(blackcomb_params[:account_id])
-    credential = tenant.root.credentials.create
-    if credential.persisted?
-      render json: json_resource(resource_class: CredentialResource, record: credential), status: :created
+    res = BlackcombUserCreate.call(params: blackcomb_params)
+    if res.success?
+      @current_jwt = Ros::Jwt.new(res.model.jwt_payload)
+      render json: json_resource(resource_class: UserResource, record: res.model), status: :created
     else
-      resource = CredentialResource.new(credential, nil)
-      handle_exception JSONAPI::Exceptions::ValidationErrors.new(resource)
+      resource = ApplicationResource.new(res, nil)
+      handle_exceptions JSONAPI::Exceptions::ValidationErrors.new(resource)
     end
   end
 
   private
 
-  def validate_platform_owner
-    return true if Apartment::Tenant.current == 'public' && context[:user].root?
-
-    render json: { errors: ['Invalid credentials'] }, status: :forbidden
-  end
-
   def blackcomb_params
-    jsonapi_params.permit(:account_id)
+    permitted_params = jsonapi_params.permit(:account_id)
+
+    HashWithIndifferentAccess.new({ current_user: context[:user] }.merge(permitted_params))
   end
 end

--- a/services/iam/app/controllers/credentials_controller.rb
+++ b/services/iam/app/controllers/credentials_controller.rb
@@ -1,4 +1,31 @@
 # frozen_string_literal: true
 
 class CredentialsController < Iam::ApplicationController
+  before_action :validate_platform_owner, only: [:blackcomb]
+
+  # TODO: Remove this once we support registration of callbacks
+  def blackcomb
+    binding.pry
+
+    tenant = Tenant.find_by_schema_or_alias(blackcomb_params[:account_id])
+    credential = tenant.root.credentials.create
+    if credential.persisted?
+      render json: json_resource(resource_class: CredentialResource, record: credential), status: :created
+    else
+      resource = CredentialResource.new(credential, nil)
+      handle_exception JSONAPI::Exceptions::ValidationErrors.new(resource)
+    end
+  end
+
+  private
+
+  def validate_platform_owner
+    return true if Apartment::Tenant.current == 'public' && context[:user].root?
+
+    render json: { errors: ['Invalid credentials'] }, status: :forbidden
+  end
+
+  def blackcomb_params
+    jsonapi_params.permit(:account_id)
+  end
 end

--- a/services/iam/app/controllers/credentials_controller.rb
+++ b/services/iam/app/controllers/credentials_controller.rb
@@ -5,8 +5,6 @@ class CredentialsController < Iam::ApplicationController
 
   # TODO: Remove this once we support registration of callbacks
   def blackcomb
-    binding.pry
-
     tenant = Tenant.find_by_schema_or_alias(blackcomb_params[:account_id])
     credential = tenant.root.credentials.create
     if credential.persisted?

--- a/services/iam/app/models/credential.rb
+++ b/services/iam/app/models/credential.rb
@@ -35,5 +35,7 @@ class Credential < Iam::ApplicationRecord
     Ros.access_key(access_key_id)
   end
 
-  def self.urn_id; :access_key_id end
+  def self.urn_id
+    :access_key_id
+  end
 end

--- a/services/iam/app/models/root.rb
+++ b/services/iam/app/models/root.rb
@@ -5,7 +5,9 @@ class Root < Iam::ApplicationRecord
   has_many :credentials, as: :owner
   # has_many :ssh_keys
 
-  def to_urn; "#{self.class.urn_base}:#{tenant.account_id}:root/#{id}" end
+  def to_urn
+    "#{self.class.urn_base}:#{tenant.account_id}:root/#{id}"
+  end
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/services/iam/app/models/user.rb
+++ b/services/iam/app/models/user.rb
@@ -63,5 +63,7 @@ class User < Iam::ApplicationRecord
          authentication_keys: [:username]
   # jwt_revocation_strategy: Devise::JWT::RevocationStrategies::Null
 
-  def jwt_payload; @jwt_payload ||= { sub: to_urn } end
+  def jwt_payload
+    @jwt_payload ||= { sub: to_urn }
+  end
 end

--- a/services/iam/app/operations/blackcomb_user_create.rb
+++ b/services/iam/app/operations/blackcomb_user_create.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+class BlackcombUserCreate < Ros::ActivityBase
+  step :valdidate_root_owner
+  failed :invalid_user, Output(:success) => End(:failure)
+  step :switch_tenant
+  failed :invalid_schema, Output(:success) => End(:failure)
+  step :create_or_find_blackcomb_user
+  failed :failed_to_create_user
+
+  private
+
+  def valdidate_root_owner(_ctx, params:, **)
+    Apartment::Tenant.current == 'public' && params[:current_user].root?
+  end
+
+  def invalid_user(_ctx, errors:, **)
+    errors.add(:user, 'Not a owner root')
+  end
+
+  def switch_tenant(_ctx, params:, **)
+    tenant = Tenant.find_by_schema_or_alias(params[:account_id])
+    return false unless tenant
+
+    tenant.switch!
+    true
+  end
+
+  def invalid_schema(_ctx, errors:, **)
+    errors.add(:account_id, 'Invalid account id')
+  end
+
+  def create_or_find_blackcomb_user(ctx, **)
+    ctx[:model] = User.find_or_initialize_by(username: 'blackcomb')
+
+    return true if ctx[:model].persisted?
+
+    password = SecureRandom.hex
+    ctx[:model].update(password: password, password_confirmation: password, confirmed_at: Time.zone.today)
+    ctx[:model].save
+  end
+
+  def failed_to_create_user(ctx, model:, **)
+    ctx[:errors] = model.errors
+  end
+end

--- a/services/iam/app/resources/credential_resource.rb
+++ b/services/iam/app/resources/credential_resource.rb
@@ -1,29 +1,9 @@
 # frozen_string_literal: true
 
 class CredentialResource < Iam::ApplicationResource
-  attributes :access_key_id, :owner_type, :owner_id, :secret_access_key,
-             :account_id
+  attributes :access_key_id, :owner_type, :owner_id, :secret_access_key
 
   filter :access_key_id
-
-  def account_id=(account_id)
-    return unless account_id
-
-    tenant = Tenant.find_by_schema_or_alias(account_id)
-    @model.owner = tenant.root
-  end
-
-  def self.creatable_fields(context)
-    if Apartment::Tenant.current == 'public' && context[:user].root?
-      [:account_id]
-    else
-      %i[owner_type owner_id]
-    end
-  end
-
-  def fetchable_fields
-    super - %i[account_id]
-  end
 
   def self.descriptions
     {

--- a/services/iam/app/resources/credential_resource.rb
+++ b/services/iam/app/resources/credential_resource.rb
@@ -11,8 +11,12 @@ class CredentialResource < Iam::ApplicationResource
   end
 
   def account_id=(account_id)
-    owner = Tenant.find_by_schema_or_alias(account_id).root
-    @model.owner = owner
+    return unless account_id
+
+    tenant = Tenant.find_by_schema_or_alias(account_id)
+    Apartment::Tenant.switch(tenant.schema_name) do
+      @model.owner = Root.first
+    end
   end
 
   def self.creatable_fields(context)

--- a/services/iam/app/resources/credential_resource.rb
+++ b/services/iam/app/resources/credential_resource.rb
@@ -7,9 +7,7 @@ class CredentialResource < Iam::ApplicationResource
   filter :access_key_id
 
   before_save do
-    unless Apartment::Tenant.current == 'public' && context[:user].root?
-      @model.owner ||= context[:user]
-    end
+    @model.owner ||= context[:user] unless Apartment::Tenant.current == 'public' && context[:user].root?
   end
 
   def account_id=(account_id)

--- a/services/iam/app/resources/credential_resource.rb
+++ b/services/iam/app/resources/credential_resource.rb
@@ -6,24 +6,18 @@ class CredentialResource < Iam::ApplicationResource
 
   filter :access_key_id
 
-  before_save do
-    @model.owner ||= context[:user] unless Apartment::Tenant.current == 'public' && context[:user].root?
-  end
-
   def account_id=(account_id)
     return unless account_id
 
     tenant = Tenant.find_by_schema_or_alias(account_id)
-    Apartment::Tenant.switch(tenant.schema_name) do
-      @model.owner = Root.first
-    end
+    @model.owner = tenant.root
   end
 
   def self.creatable_fields(context)
     if Apartment::Tenant.current == 'public' && context[:user].root?
       [:account_id]
     else
-      []
+      %i[owner_type owner_id]
     end
   end
 

--- a/services/iam/app/resources/root_resource.rb
+++ b/services/iam/app/resources/root_resource.rb
@@ -9,5 +9,6 @@ class RootResource < Iam::ApplicationResource
   filter :email
 
   def attached_policies; {} end
+
   def attached_actions; {} end
 end

--- a/services/iam/config/routes.rb
+++ b/services/iam/config/routes.rb
@@ -10,4 +10,8 @@ Ros::Iam::Engine.routes.draw do
   jsonapi_resources :policies
   jsonapi_resources :roots
   jsonapi_resources :users
+
+  # TODO: temporary route until we support registering callbacks to allow
+  # a root owner account to create a tenant
+  post '/blackcomb_credentials', to: 'credentials#blackcomb'
 end


### PR DESCRIPTION
[Define how a root user should create an app token for a specific tenant](https://perxtechnologies.atlassian.net/browse/PW-2434)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Added ability to create credentials for a root user, using the root token

# How does the implementation addresses the problem

This allows a request with a platform owner root token to create a credential for a tenant's root account. This completes the flow for blackcomb tenant agnostic deploy