### PR TITLE
[Chore] Shared examples for operation job specs

### DIFF
--- a/lib/core/spec/shared/jobs/operation_job.rb
+++ b/lib/core/spec/shared/jobs/operation_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'operation job' do
+  let(:with_arguments) { {} }
+  let(:described_operation) { described_class.name.gsub('Job', '').constantize }
+
+  before do
+    allow(described_operation).to receive(:call)
+    described_class.perform_now(with_arguments)
+  end
+
+  it 'triggers the matching operation' do
+    expect(described_operation).to have_received(:call).once.with([with_arguments])
+  end
+end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
- no jura case

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
- Shared example created to test operation jobs.

# How does the implementation addresses the problem

After merging this, we will able to test jobs in 1 line:
```ruby
RSpec.describe SomeJob, type: :job do
  include_examples 'operation job'
end
```

Or if job has arguments:

```ruby
RSpec.describe AnotherJob, type: :job do
  include_examples 'operation job' do
    let(:with_arguments) { { param1: :value } }
  end
end

```
