### PR TITLE
[PW-2559] Add gender column to cognito user

### DIFF
--- a/services/cognito/app/models/user.rb
+++ b/services/cognito/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < Cognito::ApplicationRecord
   attribute :anonymous, :boolean, default: false
 
+  enum gender: { male: 'm', feemale: 'f', other: 'o' }
+
   has_many :user_pools
   has_many :pools, through: :user_pools
 

--- a/services/cognito/app/resources/user_resource.rb
+++ b/services/cognito/app/resources/user_resource.rb
@@ -2,7 +2,7 @@
 
 class UserResource < Cognito::ApplicationResource
   attributes :title, :first_name, :last_name, :phone_number, :email_address,
-             :primary_identifier, :properties, :anonymous, :birthday
+             :primary_identifier, :properties, :anonymous, :birthday, :gender
   filter :primary_identifier
 
   filter :query, apply: lambda { |records, value, _options|

--- a/services/cognito/db/migrate/20191205023159_add_gender_to_user.rb
+++ b/services/cognito/db/migrate/20191205023159_add_gender_to_user.rb
@@ -1,0 +1,5 @@
+class AddGenderToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :gender, :string
+  end
+end

--- a/services/cognito/doc/schemas/cloud_events/cognito/user.avsc
+++ b/services/cognito/doc/schemas/cloud_events/cognito/user.avsc
@@ -101,6 +101,14 @@
       "default": null
     },
     {
+      "name": "gender",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
       "name": "urn",
       "type": [
         "null",

--- a/services/cognito/spec/dummy/db/schema.rb
+++ b/services/cognito/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_29_055605) do
+ActiveRecord::Schema.define(version: 2019_12_05_023159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2019_11_29_055605) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.date "birthday"
+    t.string "gender"
     t.index ["primary_identifier"], name: "index_users_on_primary_identifier", unique: true
   end
 

--- a/services/cognito/spec/models/user_spec.rb
+++ b/services/cognito/spec/models/user_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe User, type: :model do
     let(:subject) { create(factory_name) }
   end
 
+  describe 'attributes' do
+    let(:gender) { { male: 'm', feemale: 'f', other: 'o' } }
+    it { is_expected.to define_enum_for(:gender).with_values(gender).backed_by_column_of_type(:string) }
+  end
+
   describe 'associations' do
     it { is_expected.to have_many(:user_pools) }
     it { is_expected.to have_many(:pools).through(:user_pools) }


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[User gender and age (DOB) Information required ](https://perxtechnologies.atlassian.net/browse/PW-2559)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
- User gender added as an enum attribute with values `male, female, other`.

# How does the implementation addresses the problem

After merging this, cognito user will have a gender attribute.
