### PR TITLE
[PW-2785] current forgot password api is way to talkative for an api that works without authentication

### DIFF
--- a/services/iam/app/controllers/iam/confirmations_controller.rb
+++ b/services/iam/app/controllers/iam/confirmations_controller.rb
@@ -16,7 +16,7 @@ module Iam
         @current_user.send_confirmation_instructions
 
         if successfully_sent?(@current_user)
-          render status: :ok, json: json_resource(resource_class: user_resource, record: current_user)
+          render status: :ok, json: { message: 'ok' }
         else
           render status: :bad_request
         end
@@ -41,7 +41,7 @@ module Iam
       Apartment::Tenant.switch tenant_schema(mail_token) do
         res = User.confirm_by_token(mail_token[:token])
         if res.confirmed?
-          render status: :ok, json: json_resource(resource_class: user_resource, record: res)
+          render status: :ok, json: { message: 'ok' }
         else
           render status: :bad_request, json: { errors: res.errors }
         end

--- a/services/iam/app/controllers/iam/passwords_controller.rb
+++ b/services/iam/app/controllers/iam/passwords_controller.rb
@@ -16,7 +16,7 @@ module Iam
         @current_user.send_reset_password_instructions
 
         if successfully_sent?(@current_user)
-          render status: :ok, json: json_resource(resource_class: user_resource, record: current_user)
+          render status: :ok, json: { message: 'ok' }
         else
           render status: :bad_request
         end
@@ -44,7 +44,7 @@ module Iam
         res = User.reset_password_by_token(decoded_params)
 
         if res.persisted?
-          render status: :ok, json: json_resource(resource_class: user_resource, record: res)
+          render status: :ok, json: { message: 'ok' }
         else
           render status: :bad_request, json: { errors: res.errors }
         end

--- a/services/iam/spec/requests/users/confirmation_spec.rb
+++ b/services/iam/spec/requests/users/confirmation_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'Account confirmation', type: :request do
       it 'should allow performing an account confirmation without authentication' do
         post url, params: valid_params, headers: headers, as: :json
         expect(response).to be_successful
+        expect_json('message', 'ok')
       end
     end
 
@@ -60,6 +61,7 @@ RSpec.describe 'Account confirmation', type: :request do
 
         get url, params: params, headers: headers
         expect(response).to be_successful
+        expect_json('message', 'ok')
       end
     end
   end

--- a/services/iam/spec/requests/users/password_spec.rb
+++ b/services/iam/spec/requests/users/password_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe 'Password management', type: :request do
       it 'should allow performing a password reset/recovery without authentication' do
         post url, params: params, headers: headers, as: :json
         expect(response).to be_successful
+        expect_json('message', 'ok')
       end
     end
   end

--- a/services/iam/spec/requests/users/password_spec.rb
+++ b/services/iam/spec/requests/users/password_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'Password management', type: :request do
 
           put url, params: params, headers: request_headers, as: :json
           expect(response).to be_successful
+          expect_json('message', 'ok')
         end
       end
     end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[current forgot password api is way to talkative for an api that works without authentication](https://perxtechnologies.atlassian.net/browse/PW-2785)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Returns simple ok response for confirmations and password endpoints in IAM

# How does the implementation addresses the problem

After merging this, what are we providing extra.
