### PR TITLE
[PW-2721] Do not fetch the list of users to display the number of users in audiences table

### DIFF
--- a/services/cognito/app/resources/pool_resource.rb
+++ b/services/cognito/app/resources/pool_resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PoolResource < Cognito::ApplicationResource
-  attributes :name, :properties, :users_count
+  attributes :name, :properties, :user_count
   has_many :users
 
   filter :query, apply: lambda { |records, value, _options|
@@ -14,7 +14,15 @@ class PoolResource < Cognito::ApplicationResource
     records.where(filter_fields)
   }
 
-  def users_count
+  def self.updatable_fields(context)
+    super - [:user_count]
+  end
+
+  def self.creatable_fields(context)
+    super - [:user_count]
+  end
+
+  def user_count
     users.size
   end
 end

--- a/services/cognito/app/resources/pool_resource.rb
+++ b/services/cognito/app/resources/pool_resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PoolResource < Cognito::ApplicationResource
-  attributes :name, :properties
+  attributes :name, :properties, :users_count
   has_many :users
 
   filter :query, apply: lambda { |records, value, _options|
@@ -13,4 +13,8 @@ class PoolResource < Cognito::ApplicationResource
     filter_fields = /\D/.match?(value[0]) ? query_by_non_id_attrs : query_by_id
     records.where(filter_fields)
   }
+
+  def users_count
+    users.size
+  end
 end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'pools requests', type: :request do
   let(:mock) { true }
   let(:base_url) { u('/pools') }
   let(:url) { base_url }
+  let(:resource_attrs) { %i[name properties users_count] }
 
   describe 'GET index' do
     context 'Unauthenticated user' do
@@ -29,6 +30,7 @@ RSpec.describe 'pools requests', type: :request do
 
       context 'without users included' do
         it 'returns successful response' do
+          expect_json_keys('data.0.attributes', resource_attrs)
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
           expect_json('included', nil)
@@ -39,6 +41,7 @@ RSpec.describe 'pools requests', type: :request do
         let(:url) { "#{base_url}?include=users" }
 
         it 'returns successful response' do
+          expect_json_keys('data.0.attributes', resource_attrs)
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
           expect_json_types('included', :array)
@@ -65,6 +68,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?filter[query]=#{model.id}" }
 
             it 'returns successful response' do
+              expect_json_keys('data.0.attributes', resource_attrs)
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json('included', nil)
@@ -76,6 +80,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?include=users&filter[query]=#{model.id}" }
 
             it 'returns successful response' do
+              expect_json_keys('data.0.attributes', resource_attrs)
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json_types('included', :array)
@@ -109,6 +114,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?filter[query]=#{pool_name}" }
 
             it 'returns successful response' do
+              expect_json_keys('data.0.attributes', resource_attrs)
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json('included', nil)
@@ -120,6 +126,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?include=users&filter[query]=#{pool_name}" }
 
             it 'returns successful response' do
+              expect_json_keys('data.0.attributes', resource_attrs)
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json_types('included', :array)

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'pools requests', type: :request do
   let(:mock) { true }
   let(:base_url) { u('/pools') }
   let(:url) { base_url }
-  let(:resource_attrs) { %i[name properties user_count urn created_at updated_at properties] }
 
   describe 'GET index' do
     context 'Unauthenticated user' do
@@ -30,10 +29,9 @@ RSpec.describe 'pools requests', type: :request do
 
       context 'without users included' do
         it 'returns successful response' do
-          returns_expected_attrs
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
-          expect_json('included', nil)
+          expect_json('data.0.attributes.user_count', 1)
         end
       end
 
@@ -41,7 +39,6 @@ RSpec.describe 'pools requests', type: :request do
         let(:url) { "#{base_url}?include=users" }
 
         it 'returns successful response' do
-          returns_expected_attrs
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
           expect_json_types('included', :array)
@@ -68,7 +65,6 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?filter[query]=#{model.id}" }
 
             it 'returns successful response' do
-              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json('included', nil)
@@ -80,7 +76,6 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?include=users&filter[query]=#{model.id}" }
 
             it 'returns successful response' do
-              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json_types('included', :array)
@@ -114,7 +109,6 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?filter[query]=#{pool_name}" }
 
             it 'returns successful response' do
-              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json('included', nil)
@@ -126,7 +120,6 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?include=users&filter[query]=#{pool_name}" }
 
             it 'returns successful response' do
-              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json_types('included', :array)
@@ -153,12 +146,6 @@ RSpec.describe 'pools requests', type: :request do
           end
         end
       end
-    end
-
-    private
-
-    def returns_expected_attrs
-      expect_json_keys('data.0.attributes', resource_attrs)
     end
   end
 end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'pools requests', type: :request do
   let(:mock) { true }
   let(:base_url) { u('/pools') }
   let(:url) { base_url }
-  let(:resource_attrs) { %i[name properties users_count] }
+  let(:resource_attrs) { %i[name properties user_count urn created_at updated_at properties] }
 
   describe 'GET index' do
     context 'Unauthenticated user' do

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'pools requests', type: :request do
 
       context 'without users included' do
         it 'returns successful response' do
-          expect_json_keys('data.0.attributes', resource_attrs)
+          returns_expected_attrs
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
           expect_json('included', nil)
@@ -41,7 +41,7 @@ RSpec.describe 'pools requests', type: :request do
         let(:url) { "#{base_url}?include=users" }
 
         it 'returns successful response' do
-          expect_json_keys('data.0.attributes', resource_attrs)
+          returns_expected_attrs
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
           expect_json_types('included', :array)
@@ -68,7 +68,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?filter[query]=#{model.id}" }
 
             it 'returns successful response' do
-              expect_json_keys('data.0.attributes', resource_attrs)
+              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json('included', nil)
@@ -80,7 +80,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?include=users&filter[query]=#{model.id}" }
 
             it 'returns successful response' do
-              expect_json_keys('data.0.attributes', resource_attrs)
+              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json_types('included', :array)
@@ -114,7 +114,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?filter[query]=#{pool_name}" }
 
             it 'returns successful response' do
-              expect_json_keys('data.0.attributes', resource_attrs)
+              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json('included', nil)
@@ -126,7 +126,7 @@ RSpec.describe 'pools requests', type: :request do
             let(:url) { "#{base_url}?include=users&filter[query]=#{pool_name}" }
 
             it 'returns successful response' do
-              expect_json_keys('data.0.attributes', resource_attrs)
+              returns_expected_attrs
               expect(response).to have_http_status(:ok)
               expect_json_sizes('data', 1)
               expect_json_types('included', :array)
@@ -153,6 +153,12 @@ RSpec.describe 'pools requests', type: :request do
           end
         end
       end
+    end
+
+    private
+
+    def returns_expected_attrs
+      expect_json_keys('data.0.attributes', resource_attrs)
     end
   end
 end

--- a/services/cognito/spec/requests/pools_spec.rb
+++ b/services/cognito/spec/requests/pools_spec.rb
@@ -27,11 +27,14 @@ RSpec.describe 'pools requests', type: :request do
         get url, headers: request_headers
       end
 
+      it 'includes user count for the pool' do
+        expect_json('data.0.attributes.user_count', 1)
+      end
+
       context 'without users included' do
         it 'returns successful response' do
           expect(response).to have_http_status(:ok)
           expect_json_sizes('data', 1)
-          expect_json('data.0.attributes.user_count', 1)
         end
       end
 


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Do not fetch the list of users to display the number of users in audiences table](https://perxtechnologies.atlassian.net/browse/PW-2721)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Added users_count attr in resource, for front end to display

# How does the implementation addresses the problem

- Front end no longer has to include_users in pools endpoint query, to count and display users count

After merging this, what are we providing extra.
