### PR TITLE
[PW-2839 ] Check user is confirmed before login

### DIFF
--- a/services/iam/app/controllers/users/sessions_controller.rb
+++ b/services/iam/app/controllers/users/sessions_controller.rb
@@ -6,6 +6,9 @@ module Users
 
     def login_user!
       @current_user = User.find_by(username: sign_in_params[:username])
+      return if current_user.nil?
+      return unless current_user.confirmed?
+
       current_user&.valid_password? sign_in_params[:password]
     end
 

--- a/services/iam/spec/requests/users/authentication_spec.rb
+++ b/services/iam/spec/requests/users/authentication_spec.rb
@@ -16,40 +16,62 @@ RSpec.describe 'User Authentication', type: :request do
       post url, params: params, as: :json
     end
 
-    context 'with invalid credentials' do
-      let(:params) { { data: { attributes: invalid_attributes } } }
-      it 'returns unauthorized status' do
-        expect(response).to be_unauthorized
+    context 'Invalid request' do
+      context 'with invalid credentials' do
+        let(:params) { { data: { attributes: invalid_attributes } } }
+        it 'returns unauthorized status' do
+          expect(response).to be_unauthorized
+        end
+      end
+
+      context 'without :account_id or :alias' do
+        let(:params) { { data: { attributes: valid_attributes } } }
+        it 'returns unauthorized status' do
+          expect(response).to be_unauthorized
+        end
+      end
+
+      context 'unconfirmed user with valid request' do
+        let(:params) { { data: { attributes: valid_attributes.merge(account_id: tenant.account_id) } } }
+        let(:user) do
+          create(
+            :user,
+            :within_schema,
+            username: 'test_user',
+            password: '123456',
+            schema: tenant.schema_name,
+            confirmed_at: nil
+          )
+        end
+
+        it 'returns unauthorized status' do
+          expect(response).to be_unauthorized
+        end
       end
     end
 
-    context 'without :account_id or :alias' do
-      let(:params) { { data: { attributes: valid_attributes } } }
-      it 'returns error status' do
-        expect(response).to be_unauthorized
-      end
-    end
+    context 'Valid request' do
+      context 'with :account_id' do
+        let(:params) { { data: { attributes: valid_attributes.merge(account_id: tenant.account_id) } } }
 
-    context 'with :account_id' do
-      let(:params) { { data: { attributes: valid_attributes.merge(account_id: tenant.account_id) } } }
+        it 'returns success status' do
+          expect(response).to be_successful
+        end
 
-      it 'returns success status' do
-        expect(response).to be_successful
-      end
-
-      it 'sets the authorization header with the token for the user' do
-        expect(response.headers['Authorization']).to_not be_nil
-      end
-    end
-
-    context 'with :account_alias' do
-      let(:params) { { data: { attributes: valid_attributes.merge(account_id: tenant.alias) } } }
-      it 'returns success status' do
-        expect(response).to be_successful
+        it 'sets the authorization header with the token for the user' do
+          expect(response.headers['Authorization']).to_not be_nil
+        end
       end
 
-      it 'sets the authorization header with the token for the user' do
-        expect(response.headers['Authorization']).to_not be_nil
+      context 'with :account_alias' do
+        let(:params) { { data: { attributes: valid_attributes.merge(account_id: tenant.alias) } } }
+        it 'returns success status' do
+          expect(response).to be_successful
+        end
+
+        it 'sets the authorization header with the token for the user' do
+          expect(response.headers['Authorization']).to_not be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Unconfirmed users should not be able to login](https://perxtechnologies.atlassian.net/browse/PW-2839)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- added `confirmed?` check for IAM usrs's before login

# How does the implementation addresses the problem

After merging this, what are we providing extra.
