### PR TITLE
core: only load mq/storage if explitly enabled

### DIFF
--- a/lib/core/lib/ros/infra.rb
+++ b/lib/core/lib/ros/infra.rb
@@ -15,7 +15,8 @@ module Ros
       def initialize(resources_settings)
         @resources = ActiveSupport::OrderedOptions.new
         %i(mq storage).each do |service|
-          next unless resources = resources_settings.dig(service)
+          resources = resources_settings.dig(service)
+          next unless resources&.primary&.enabled
           @resources[service] = ActiveSupport::OrderedOptions.new
           resource_type = "Ros::Infra::#{service.to_s.classify}".constantize.resource_type
           next unless (resource = resources.dig(resource_type))


### PR DESCRIPTION
# Problem
By default ros-cli will write out config for mq and storage and the `infra.rb` loader doesn't care if they have been enabled but only if there is configuration.

As a consequence, ros will try to load mq even if not explicitly enabled causing things to blow up as `aws-sdk-sqs` is not included in core.

# Solution
Check if we are explicitly enabled before loading mq.

# Background
Due to the way we build the containers, the `aws-sdk-sqs` gem was being included everywhere thus hiding the problem. The workaround mentioned in #150 is now no longer needed.