### PR TITLE
[PW-2899] Modify Ros::ApplicationRecordConcern to include record operation as part of the cloud event data

### DIFF
--- a/lib/core/app/models/concerns/ros/application_record_concern.rb
+++ b/lib/core/app/models/concerns/ros/application_record_concern.rb
@@ -34,7 +34,7 @@ module Ros
           convert_attributes(name, value)
         end
 
-        avro_attributes.to_h.merge('urn' => to_urn, '_op' => after_commit_trigger)
+        avro_attributes.to_h.merge('urn' => to_urn, '_op' => type_of_callback_trigger)
       end
 
       def convert_attributes(name, value)
@@ -45,7 +45,7 @@ module Ros
         end
       end
 
-      def after_commit_trigger
+      def type_of_callback_trigger
         %i[create update destroy].each do |action|
           return action.to_s if transaction_include_any_action?([action])
         end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Modify Ros::ApplicationRecordConcern to include record operation as part of the cloud event data](https://perxtechnologies.atlassian.net/browse/PW-2899)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Using transaction_include_any_action?([action]) to identify trigger and merge in cloud_event_data

# How does the implementation addresses the problem

- Should be able to have a field called _op with the type of trigger of an after_commit transaction

After merging this, what are we providing extra.
