### PR TITLE
[PW-2900] Modify avro schema generator to include an optional field `_op`

### DIFF
--- a/lib/core/lib/generators/avro/avro_builder.rb
+++ b/lib/core/lib/generators/avro/avro_builder.rb
@@ -40,6 +40,7 @@ class AvroBuilder
     end
 
     all_attributes.push(attribute_hash('urn', 'string'))
+    all_attributes.push(attribute_hash('_op', 'string'))
   end
 
   def data_type(column)

--- a/lib/core/lib/generators/avro/avro_builder.rb
+++ b/lib/core/lib/generators/avro/avro_builder.rb
@@ -39,8 +39,7 @@ class AvroBuilder
       attribute_hash(column.name, data_type(column))
     end
 
-    all_attributes.push(attribute_hash('urn', 'string'))
-    all_attributes.push(attribute_hash('_op', 'string'))
+    all_attributes.push(*optional_attributes)
   end
 
   def data_type(column)
@@ -72,5 +71,12 @@ class AvroBuilder
 
   def model_columns
     model.columns
+  end
+
+  def optional_attributes
+    [
+      attribute_hash('urn', 'string'),
+      attribute_hash('_op', 'string')
+    ]
   end
 end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Modify avro schema generator to include an optional field `_op`](https://perxtechnologies.atlassian.net/browse/PW-2900)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Add optional attribute _op to Avro Builder

# How does the implementation addresses the problem

After merging this, what are we providing extra.
