### PR TITLE
[PW-2995] Return user data upon successful password reset

### DIFF
--- a/services/iam/app/controllers/iam/passwords_controller.rb
+++ b/services/iam/app/controllers/iam/passwords_controller.rb
@@ -46,7 +46,7 @@ module Iam
         if res.persisted?
           res.confirm unless res.confirmed?
           @current_jwt = Ros::Jwt.new(res.jwt_payload)
-          render status: :ok, json: { message: 'ok' }
+          render status: :ok, json: json_resource(resource_class: user_resource, record: res)
         else
           render status: :bad_request, json: { errors: res.errors }
         end

--- a/services/iam/spec/requests/users/password_spec.rb
+++ b/services/iam/spec/requests/users/password_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe 'Password management', type: :request do
           put url, params: params, headers: request_headers, as: :json
           expect(response).to be_successful
           expect(response.headers['Authorization']).to_not be_nil
-          expect_json('message', 'ok')
           expect(user.confirmed?).to be_truthy
         end
       end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[In response upon successful password reset need add user data](https://perxtechnologies.atlassian.net/browse/PW-2995)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
- Return full user resource upon sucessful password reset

# How does the implementation addresses the problem

After merging this, FE will be able to automatically log user in after successful password reset.
