### PR TITLE
[Hotfix] Fixed cognito route

### DIFF
--- a/services/cognito/config/routes.rb
+++ b/services/cognito/config/routes.rb
@@ -10,4 +10,5 @@ Ros::Cognito::Engine.routes.draw do
   jsonapi_resources :endpoints
 
   resources :metabase_token, only: [:show]
+  post 'login', to: 'login#create'
 end

--- a/services/cognito/spec/dummy/config/routes.rb
+++ b/services/cognito/spec/dummy/config/routes.rb
@@ -4,6 +4,5 @@ Rails.application.routes.draw do
   extend Ros::Routes
   mount Ros::Core::Engine => Ros.dummy_mount_path
   mount Ros::Cognito::Engine => Ros.dummy_mount_path
-  post '/login', to: 'login#create'
   catch_not_found
 end


### PR DESCRIPTION
N/a

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Moved route to the engine instead of spec dummy app. This is because the engine is mounted and therefore it fails to find the path when we run it locally.

# How does the implementation addresses the problem

This fixes the route finding when running locally
