### PR TITLE
Pw 3025 create load test for daichi workflow

### DIFF
--- a/lib/core/lib/generators/ros/integration_test/integration_test_generator.rb
+++ b/lib/core/lib/generators/ros/integration_test/integration_test_generator.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Ros
-  class IntegrationTestGenerator < Rails::Generators::Base
+  class IntegrationTestGenerator < Rails::Generators::NamedBase
     def create_files
-      template(source, "#{destination}/#{Settings.service.name}.py", values)
+      template(source, "#{destination}/#{name}.py", values)
     end
 
     private

--- a/lib/core/lib/template/integration_test.yml.erb
+++ b/lib/core/lib/template/integration_test.yml.erb
@@ -7,8 +7,9 @@ from locust import HttpLocust, task, seq_task, TaskSet, TaskSequence
 # from lib.service_name import model_name
 
 class <%=values.service_name%>(TaskSequence):
-  def on_start(self):
-    helper.create_and_login_as_cognito_user(self)
+  def setup(self):
+    iam_response = helper.login_as_iam_user(self)
+    self.response['iam_header'] = { "authorization": iam_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
   # @seq_task(1)
   # @task(2)

--- a/lib/core/lib/template/integration_test.yml.erb
+++ b/lib/core/lib/template/integration_test.yml.erb
@@ -4,22 +4,21 @@ import os
 import json
 from locust import HttpLocust, task, seq_task, TaskSet, TaskSequence
 
+from lib.iam import user
 # from lib.service_name import model_name
 
 class <%=values.service_name%>(TaskSequence):
   response = {}
 
   def setup(self):
-    iam_response = helper.login_as_iam_user(self)
+    iam_response = user.login_as_iam_user(self, account_id, username, password)
     self.response['iam_header'] = { "authorization": iam_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
   # @seq_task(1)
-  # @task(2)
   # def do_task_1(self):
   # model_name.endpoint_library_method(self)
 
   # @seq_task(2)
-  # @task(2)
   # def do_task_2(self):
   # model_name.endpoint_library_method(self)
 

--- a/lib/core/lib/template/integration_test.yml.erb
+++ b/lib/core/lib/template/integration_test.yml.erb
@@ -7,6 +7,8 @@ from locust import HttpLocust, task, seq_task, TaskSet, TaskSequence
 # from lib.service_name import model_name
 
 class <%=values.service_name%>(TaskSequence):
+  response = {}
+
   def setup(self):
     iam_response = helper.login_as_iam_user(self)
     self.response['iam_header'] = { "authorization": iam_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }

--- a/lib/core/lib/template/locust_endpoint.yml.erb
+++ b/lib/core/lib/template/locust_endpoint.yml.erb
@@ -1,12 +1,12 @@
 import json
 
-def get_all_<%=values.service_name%>_<%=values.plural_name%>(self):
-  self.client.get('<%=values.service_name%>/<%=values.plural_name%>', headers=self.header)
+def get_all_<%=values.service_name%>_<%=values.plural_name%>(self, header):
+  self.client.get('<%=values.service_name%>/<%=values.plural_name%>', headers=header)
 
-def get_<%=values.service_name%>_<%=values.name%>(self, id):
+def get_<%=values.service_name%>_<%=values.name%>(self, id, header):
   path = ('<%=values.service_name%>/<%=values.plural_name%>/%s' %(id))
-  self.client.get(path, headers=self.header)
+  self.client.get(path, headers=header)
 
-def create_<%=values.service_name%>_<%=values.plural_name%>(self<%=values.extra_args%>):
+def create_<%=values.service_name%>_<%=values.name%>(self<%=values.extra_args%>, header):
   payload = <%=payload%>
-  return self.client.post('<%=values.service_name%>/<%=values.plural_name%>', data=json.dumps(payload), headers=self.header)
+  return self.client.post('<%=values.service_name%>/<%=values.plural_name%>', data=json.dumps(payload), headers=header)

--- a/lib/core/lib/template/locust_endpoint.yml.erb
+++ b/lib/core/lib/template/locust_endpoint.yml.erb
@@ -10,3 +10,8 @@ def get_<%=values.service_name%>_<%=values.name%>(self, id, header):
 def create_<%=values.service_name%>_<%=values.name%>(self<%=values.extra_args%>, header):
   payload = <%=payload%>
   return self.client.post('<%=values.service_name%>/<%=values.plural_name%>', data=json.dumps(payload), headers=header)
+
+def update_<%=values.service_name%>_<%=values.name%>(self, id, attributes, header):
+  payload = { 'data': { 'type': '<%=values.plural_name%>', 'id': id, 'attributes': attributes } }
+  path = ('<%=values.service_name%>/<%=values.plural_name%>/%s' %(id))
+  self.client.patch(path, data=json.dumps(payload), headers=header)

--- a/sre/lib/base/helper.py
+++ b/sre/lib/base/helper.py
@@ -13,35 +13,35 @@ def login_as_iam_user(self):
   self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
   return iam_login_response
 
-def create_cognito_pool(self):
+def create_cognito_pool(self, header):
   pool_name = Faker().pystr()
   payload = { "data": { "type": "pools", "attributes": { "name": pool_name } } }
-  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=self.response['iam_header'] )
+  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=header )
   return pool_response
 
-def create_anonymous_user(self, identifier):
+def create_anonymous_user(self, identifier, header):
   payload = { "data": { "type": "users", "attributes": { "primary_identifier": identifier, 'anonymous': True } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.response['iam_header'] )
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=header )
 
-def login_anonymous_user(self, identifier):
+def login_anonymous_user(self, identifier, header):
   payload = { "data": { "type": "login", "attributes": { "primary_identifier": identifier } } }
-  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.response['iam_header'] )
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=header )
   self.anonymous_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
-def create_cognito_user(self, identifier, pool_id):
+def create_cognito_user(self, identifier, pool_id, header):
   payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": pool_id }] } } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.response['iam_header'] )
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=header )
 
-def login_cognito_user(self, identifier):
+def login_cognito_user(self, identifier, header):
   payload = { "data": { "attributes": { "primary_identifier": identifier } } }
-  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.response['iam_header'] )
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=header )
   self.cognito_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
-def cognito_chown_request(self, anonymous_ids, cognito_id):
+def cognito_chown_request(self, anonymous_ids, cognito_id, header):
   payload = { "data": { "type": "chown_requests", "attributes": { "from_ids": anonymous_ids, "to_id": cognito_id } } }
-  self.client.post('cognito/chown_requests', data=json.dumps(payload), headers=self.anonymous_header)
+  self.client.post('cognito/chown_requests', data=json.dumps(payload), headers=header)
 
-def create_and_login_as_cognito_user(self, pool_id):
+def create_and_login_as_cognito_user(self, pool_id, header):
   identifier = Faker().pystr()
-  create_cognito_user(self, identifier, pool_id)
-  login_cognito_user(self, identifier)
+  create_cognito_user(self, identifier, pool_id, header)
+  login_cognito_user(self, identifier, header)

--- a/sre/lib/base/helper.py
+++ b/sre/lib/base/helper.py
@@ -1,47 +1,11 @@
 import json
 import pdb
 import os
+
+from lib.cognito import user as cognito_user
 from faker import Faker
-
-def create_iam_user(self):
-  payload =  { "data": { "type": "users", "attributes": { "username": Faker().name(), "time_zone": "SGT" } } }
-  self.client.post('iam/users', data=json.dumps(payload))
-
-def login_as_iam_user(self):
-  payload = { "data": { "attributes": { "account_id": "generic", "username": "Admin", "password": "asdfjkl;" } } }
-  iam_login_response = self.client.post('iam/users/sign_in', data=json.dumps(payload), headers={'content-type': 'application/json'})
-  self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
-  return iam_login_response
-
-def create_cognito_pool(self, header):
-  pool_name = Faker().pystr()
-  payload = { "data": { "type": "pools", "attributes": { "name": pool_name } } }
-  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=header )
-  return pool_response
-
-def create_anonymous_user(self, identifier, header):
-  payload = { "data": { "type": "users", "attributes": { "primary_identifier": identifier, 'anonymous': True } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers=header )
-
-def login_anonymous_user(self, identifier, header):
-  payload = { "data": { "type": "login", "attributes": { "primary_identifier": identifier } } }
-  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=header )
-  self.anonymous_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
-
-def create_cognito_user(self, identifier, pool_id, header):
-  payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": pool_id }] } } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers=header )
-
-def login_cognito_user(self, identifier, header):
-  payload = { "data": { "attributes": { "primary_identifier": identifier } } }
-  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=header )
-  self.cognito_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
-
-def cognito_chown_request(self, anonymous_ids, cognito_id, header):
-  payload = { "data": { "type": "chown_requests", "attributes": { "from_ids": anonymous_ids, "to_id": cognito_id } } }
-  self.client.post('cognito/chown_requests', data=json.dumps(payload), headers=header)
 
 def create_and_login_as_cognito_user(self, pool_id, header):
   identifier = Faker().pystr()
-  create_cognito_user(self, identifier, pool_id, header)
-  login_cognito_user(self, identifier, header)
+  cognito_user.create_cognito_user(self, identifier, pool_id, header)
+  cognito_user.login_cognito_user(self, identifier, header)

--- a/sre/lib/base/helper.py
+++ b/sre/lib/base/helper.py
@@ -5,26 +5,34 @@ from faker import Faker
 
 def create_iam_user(self):
   payload =  { "data": { "type": "users", "attributes": { "username": Faker().name(), "time_zone": "SGT" } } }
-  self.client.post('iam/users', data=json.dumps(payload), headers={"authorization": self.token, 'content-type': 'application/vnd.api+json'})
+  self.client.post('iam/users', data=json.dumps(payload), headers=self.iam_header)
 
 def login_as_iam_user(self):
-  payload = { "data": { "attributes": { "account_id": "telco", "username": "Admin", "password": "asdfjkl;" } } }
+  payload = { "data": { "attributes": { "account_id": "generic", "username": "Admin", "password": "asdfjkl;" } } }
   return self.client.post('iam/users/sign_in', data=json.dumps(payload), headers={'content-type': 'application/json'})
 
+def create_cognito_pool(self):
+  pool_name = Faker().pystr()
+  payload = { "data": { "type": "pools", "attributes": { "name": pool_name } } }
+  return self.client.post('cognito/pools', data=json.dumps(payload), headers=self.iam_header )
+
 def create_cognito_user(self, identifier):
-  payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers={"authorization": self.token, 'content-type': 'application/vnd.api+json'} )
+  payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": self.pool_id }] } } } }
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.iam_header )
 
 def login_cognito_user(self, identifier):
   payload = { "data": { "attributes": { "primary_identifier": identifier } } }
-  return self.client.post('cognito/login', data=json.dumps(payload), headers={"authorization": self.token, 'content-type': 'application/vnd.api+json' } )
+  return self.client.post('cognito/login', data=json.dumps(payload), headers=self.iam_header )
 
 def create_and_login_as_cognito_user(self):
   iam_login_response = login_as_iam_user(self)
-  self.token = iam_login_response.headers['Authorization']
+  self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+
+  pool_response = create_cognito_pool(self)
+  self.pool_id = json.loads(pool_response.content)['data']['id']
 
   identifier = Faker().pystr()
   create_cognito_user(self, identifier)
 
   login_response = login_cognito_user(self, identifier)
-  self.header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+  self.cognito_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }

--- a/sre/lib/base/helper.py
+++ b/sre/lib/base/helper.py
@@ -11,39 +11,37 @@ def login_as_iam_user(self):
   payload = { "data": { "attributes": { "account_id": "generic", "username": "Admin", "password": "asdfjkl;" } } }
   iam_login_response = self.client.post('iam/users/sign_in', data=json.dumps(payload), headers={'content-type': 'application/json'})
   self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+  return iam_login_response
 
 def create_cognito_pool(self):
   pool_name = Faker().pystr()
   payload = { "data": { "type": "pools", "attributes": { "name": pool_name } } }
-  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=self.iam_header )
-  self.pool_id = json.loads(pool_response.content)['data']['id']
+  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=self.response['iam_header'] )
+  return pool_response
 
 def create_anonymous_user(self, identifier):
   payload = { "data": { "type": "users", "attributes": { "primary_identifier": identifier, 'anonymous': True } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.iam_header )
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.response['iam_header'] )
 
 def login_anonymous_user(self, identifier):
   payload = { "data": { "type": "login", "attributes": { "primary_identifier": identifier } } }
-  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.iam_header )
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.response['iam_header'] )
   self.anonymous_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
-def create_cognito_user(self, identifier):
-  payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": self.pool_id }] } } } }
-  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.iam_header )
+def create_cognito_user(self, identifier, pool_id):
+  payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": pool_id }] } } } }
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.response['iam_header'] )
 
 def login_cognito_user(self, identifier):
   payload = { "data": { "attributes": { "primary_identifier": identifier } } }
-  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.iam_header )
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.response['iam_header'] )
   self.cognito_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
 def cognito_chown_request(self, anonymous_ids, cognito_id):
   payload = { "data": { "type": "chown_requests", "attributes": { "from_ids": anonymous_ids, "to_id": cognito_id } } }
   self.client.post('cognito/chown_requests', data=json.dumps(payload), headers=self.anonymous_header)
 
-def create_and_login_as_cognito_user(self):
-  login_as_iam_user(self)
-  create_cognito_pool(self)
-
+def create_and_login_as_cognito_user(self, pool_id):
   identifier = Faker().pystr()
-  create_cognito_user(self, identifier)
+  create_cognito_user(self, identifier, pool_id)
   login_cognito_user(self, identifier)

--- a/sre/lib/base/helper.py
+++ b/sre/lib/base/helper.py
@@ -5,16 +5,27 @@ from faker import Faker
 
 def create_iam_user(self):
   payload =  { "data": { "type": "users", "attributes": { "username": Faker().name(), "time_zone": "SGT" } } }
-  self.client.post('iam/users', data=json.dumps(payload), headers=self.iam_header)
+  self.client.post('iam/users', data=json.dumps(payload))
 
 def login_as_iam_user(self):
   payload = { "data": { "attributes": { "account_id": "generic", "username": "Admin", "password": "asdfjkl;" } } }
-  return self.client.post('iam/users/sign_in', data=json.dumps(payload), headers={'content-type': 'application/json'})
+  iam_login_response = self.client.post('iam/users/sign_in', data=json.dumps(payload), headers={'content-type': 'application/json'})
+  self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
 def create_cognito_pool(self):
   pool_name = Faker().pystr()
   payload = { "data": { "type": "pools", "attributes": { "name": pool_name } } }
-  return self.client.post('cognito/pools', data=json.dumps(payload), headers=self.iam_header )
+  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=self.iam_header )
+  self.pool_id = json.loads(pool_response.content)['data']['id']
+
+def create_anonymous_user(self, identifier):
+  payload = { "data": { "type": "users", "attributes": { "primary_identifier": identifier, 'anonymous': True } } }
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=self.iam_header )
+
+def login_anonymous_user(self, identifier):
+  payload = { "data": { "type": "login", "attributes": { "primary_identifier": identifier } } }
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.iam_header )
+  self.anonymous_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
 
 def create_cognito_user(self, identifier):
   payload =  { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": self.pool_id }] } } } }
@@ -22,17 +33,17 @@ def create_cognito_user(self, identifier):
 
 def login_cognito_user(self, identifier):
   payload = { "data": { "attributes": { "primary_identifier": identifier } } }
-  return self.client.post('cognito/login', data=json.dumps(payload), headers=self.iam_header )
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=self.iam_header )
+  self.cognito_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+
+def cognito_chown_request(self, anonymous_ids, cognito_id):
+  payload = { "data": { "type": "chown_requests", "attributes": { "from_ids": anonymous_ids, "to_id": cognito_id } } }
+  self.client.post('cognito/chown_requests', data=json.dumps(payload), headers=self.anonymous_header)
 
 def create_and_login_as_cognito_user(self):
-  iam_login_response = login_as_iam_user(self)
-  self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
-
-  pool_response = create_cognito_pool(self)
-  self.pool_id = json.loads(pool_response.content)['data']['id']
+  login_as_iam_user(self)
+  create_cognito_pool(self)
 
   identifier = Faker().pystr()
   create_cognito_user(self, identifier)
-
-  login_response = login_cognito_user(self, identifier)
-  self.cognito_header = { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+  login_cognito_user(self, identifier)

--- a/sre/lib/cognito/chown_request.py
+++ b/sre/lib/cognito/chown_request.py
@@ -1,0 +1,5 @@
+import json
+
+def create_cognito_chown_request(self, anonymous_ids, cognito_id, header):
+  payload = { "data": { "type": "chown_requests", "attributes": { "from_ids": anonymous_ids, "to_id": cognito_id } } }
+  self.client.post('cognito/chown_requests', data=json.dumps(payload), headers=header)

--- a/sre/lib/cognito/pool.py
+++ b/sre/lib/cognito/pool.py
@@ -1,0 +1,8 @@
+import json
+from faker import Faker
+
+def create_cognito_pool(self, header):
+  pool_name = Faker().pystr()
+  payload = { "data": { "type": "pools", "attributes": { "name": pool_name } } }
+  pool_response = self.client.post('cognito/pools', data=json.dumps(payload), headers=header )
+  return pool_response

--- a/sre/lib/cognito/user.py
+++ b/sre/lib/cognito/user.py
@@ -1,0 +1,19 @@
+import json
+
+def create_cognito_user(self, identifier, pool_id, header, anonymous=False):
+  if anonymous:
+    payload = { "data": { "type": "users", "attributes": { "primary_identifier": identifier, 'anonymous': True } } }
+  else:
+    payload = { "data": { "type": "users", "attributes": { "primary_identifier": identifier }, "relationships": { "pools": { "data": [{ "type": "pools", "id": pool_id }] } } } }
+
+  return self.client.post('cognito/users', data=json.dumps(payload), headers=header )
+
+def login_cognito_user(self, identifier, header, anonymous=False):
+  payload = { "data": { "attributes": { "primary_identifier": identifier } } }
+  login_response = self.client.post('cognito/login', data=json.dumps(payload), headers=header )
+
+  header =  { "authorization": login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+  if anonymous:
+    self.anonymous_header = header
+  else:
+    self.cognito_header = header

--- a/sre/lib/iam/user.py
+++ b/sre/lib/iam/user.py
@@ -1,0 +1,12 @@
+import json
+from faker import Faker
+
+def create_iam_user(self):
+  payload =  { "data": { "type": "users", "attributes": { "username": Faker().name(), "time_zone": "SGT" } } }
+  self.client.post('iam/users', data=json.dumps(payload))
+
+def login_as_iam_user(self, account_id, username, password):
+  payload = { "data": { "attributes": { "account_id":  account_id, "username": username, "password": password } } }
+  iam_login_response = self.client.post('iam/users/sign_in', data=json.dumps(payload), headers={'content-type': 'application/json'})
+  self.iam_header = { "authorization": iam_login_response.headers['Authorization'], 'content-type': 'application/vnd.api+json' }
+  return iam_login_response

--- a/sre/lib/organization/org.py
+++ b/sre/lib/organization/org.py
@@ -1,12 +1,12 @@
 import json
 
-def get_all_organization_orgs(self):
-  self.client.get('organization/orgs', headers=self.cognito_header)
+def get_all_organization_orgs(self, header):
+  self.client.get('organization/orgs', headers=header)
 
-def get_organization_org(self, id):
+def get_organization_org(self, id, header):
   path = ('organization/orgs/%s' %(id))
-  self.client.get(path, headers=self.cognito_header)
+  self.client.get(path, headers=header)
 
-def create_organization_orgs(self):
+def create_organization_orgs(self, header):
   payload = { 'data': { 'type': 'orgs', 'attributes': { 'name': "MyString", 'description': "MyString", 'properties': {} } } }
-  return self.client.post('organization/orgs', data=json.dumps(payload), headers=self.response['iam_header'])
+  return self.client.post('organization/orgs', data=json.dumps(payload), headers=header)

--- a/sre/lib/organization/org.py
+++ b/sre/lib/organization/org.py
@@ -9,4 +9,4 @@ def get_organization_org(self, id):
 
 def create_organization_orgs(self):
   payload = { 'data': { 'type': 'orgs', 'attributes': { 'name': "MyString", 'description': "MyString", 'properties': {} } } }
-  return self.client.post('organization/orgs', data=json.dumps(payload), headers=self.iam_header)
+  return self.client.post('organization/orgs', data=json.dumps(payload), headers=self.response['iam_header'])

--- a/sre/lib/organization/org.py
+++ b/sre/lib/organization/org.py
@@ -1,12 +1,12 @@
 import json
 
 def get_all_organization_orgs(self):
-  self.client.get('organization/orgs', headers=self.header)
+  self.client.get('organization/orgs', headers=self.cognito_header)
 
 def get_organization_org(self, id):
   path = ('organization/orgs/%s' %(id))
-  self.client.get(path, headers=self.header)
+  self.client.get(path, headers=self.cognito_header)
 
 def create_organization_orgs(self):
   payload = { 'data': { 'type': 'orgs', 'attributes': { 'name': "MyString", 'description': "MyString", 'properties': {} } } }
-  return self.client.post('organization/orgs', data=json.dumps(payload), headers=self.header)
+  return self.client.post('organization/orgs', data=json.dumps(payload), headers=self.iam_header)


### PR DESCRIPTION
# Refer to the JIRA issue id if any. Include the link to the issue. E.g:
[Create load test for daichi workflow](https://perxtechnologies.atlassian.net/browse/PW-3025)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Updated `IntegrationTestGenerator` to be a named based generator
- Updated `integration_test.yml` to use setup instead of on start
- Updated `locust_endpoint.yml.erb` to support update method
- Shift endpoints in individual services from helper file to their own folders 

# How does the implementation addresses the problem

To generate the 

Provide methods to support the daiichi load test work flow on whistler

To generate integration test files in the future, you can run

`rails g ros:integration_test scenario_name`