### PR TITLE
core: rspec rightfully warns that we are too fixated on KeyError

### DIFF
--- a/lib/core/spec/shared/models/example_groups.rb
+++ b/lib/core/spec/shared/models/example_groups.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'application record concern' do
   let(:factory_name) { described_class.name.underscore.to_sym }
 
   it 'has a factory' do
-    expect { create(factory_name) }.not_to raise_error(KeyError)
+    expect { create(factory_name) }.not_to raise_error
   end
 
   before do


### PR DESCRIPTION
We expect the factory not to blow up - not that it doesn't blow up with a certain error.