### PR TITLE
[Hotfix] put operation_class back to Ros::ChownJob

### DIFF
--- a/lib/core/app/jobs/ros/chown_job.rb
+++ b/lib/core/app/jobs/ros/chown_job.rb
@@ -2,5 +2,8 @@
 
 module Ros
   class ChownJob < Ros::ApplicationJob
+    def operation_class
+      "#{Settings.service.name}::Chown".underscore.classify.constantize
+    end
   end
 end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
- somehow related to [Update end to end test 'anonymous flow game play' to include fetching of campaign](https://perxtechnologies.atlassian.net/browse/PW-3044)
- [uninitialized constant Ros::Chown Did you mean? Ros::ChownJob](https://sentry.io/organizations/perx-technologies-pte-ltd/issues/1413098443/?environment=production-uat-dev1&project=1819291&query=is%3Aunresolved&statsPeriod=24h)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.
- `operation_class` was deleted from `Ros::ChownJob` during optimization, but it's need to be there, because `Ros::ChownJob` running operations in different services.

# How does the implementation addresses the problem

After merging this, we will have `chown` works again.
