### PR TITLE
storage: do not depend on localstack when running tests

### DIFF
--- a/services/storage/spec/dummy/config/storage.yml
+++ b/services/storage/spec/dummy/config/storage.yml
@@ -30,5 +30,5 @@ development:
   <<: *amazon_app
 
 test:
-  # <<: *disk
-  <<: *localstack
+  <<: *disk
+  # <<: *localstack


### PR DESCRIPTION
If localstack is not available or buckets are misconfigured when running the tests, the storage tests will wait for timeouts before continuing due to tenant changes causing a writeout (and subsequent upload) of `users.conf`.

Instead, have ActiveStorage simply store to disk.

