### PR TITLE
[PW-3165] Valid campaign created is stuck at scheduled status for more than half an hour

### DIFF
--- a/services/cognito/app/operations/pool_create.rb
+++ b/services/cognito/app/operations/pool_create.rb
@@ -39,7 +39,6 @@ class PoolCreate < Ros::ActivityBase
   end
 
   def apply_segment(ctx, base_pool:, params:, **)
-    # TODO: handle scenario where SegmentsApply has an empty pool
     segment_result = SegmentsApply.call(users: base_pool.users, segments: params[:segments])
     return false unless segment_result.success?
 

--- a/services/cognito/app/operations/pool_create.rb
+++ b/services/cognito/app/operations/pool_create.rb
@@ -8,8 +8,8 @@ class PoolCreate < Ros::ActivityBase
 
   step :find_base_pool
   failed :base_pool_not_found, Output(:success) => End(:failure)
-  step :fetch_users
-  failed :users_not_fetched, Output(:success) => End(:failure)
+  step :apply_segment
+  failed :fail_to_apply_segment, Output(:success) => End(:failure)
   step :create_pool
   failed :pool_not_created, Output(:success) => End(:failure)
   step :add_users_to_pool
@@ -38,16 +38,16 @@ class PoolCreate < Ros::ActivityBase
     errors.add(:base_pool, "Can't find base pool with id: #{params[:base_pool_id]}")
   end
 
-  def fetch_users(ctx, base_pool:, params:, **)
-    # TODO: handle scenario where SegmentsApply fails
+  def apply_segment(ctx, base_pool:, params:, **)
     # TODO: handle scenario where SegmentsApply has an empty pool
-    ctx[:users] = SegmentsApply.call(users: base_pool.users, segments: params[:segments]).model
-    # NOTE: don't create an empty pool
-    ctx[:users].count.positive?
+    segment_result = SegmentsApply.call(users: base_pool.users, segments: params[:segments])
+    return false unless segment_result.success?
+
+    ctx[:users] = segment_result.model
   end
 
-  def users_not_fetched(_ctx, errors:, **)
-    errors.add(:users, "Can't fetch users for pool")
+  def fail_to_apply_segment(_ctx, errors:, **)
+    errors.add(:users, 'Failed to apply segment')
   end
 
   def create_pool(ctx, **)

--- a/services/cognito/app/operations/pool_create.rb
+++ b/services/cognito/app/operations/pool_create.rb
@@ -39,6 +39,8 @@ class PoolCreate < Ros::ActivityBase
   end
 
   def fetch_users(ctx, base_pool:, params:, **)
+    # TODO: handle scenario where SegmentsApply fails
+    # TODO: handle scenario where SegmentsApply has an empty pool
     ctx[:users] = SegmentsApply.call(users: base_pool.users, segments: params[:segments]).model
     # NOTE: don't create an empty pool
     ctx[:users].count.positive?

--- a/services/cognito/app/operations/segments/age.rb
+++ b/services/cognito/app/operations/segments/age.rb
@@ -41,7 +41,7 @@ module Segments
     end
 
     def segment_not_applied(_ctx, errors:, segment:, **)
-      errors.add(:model, "Can't apply age segment: #{segment}")
+      errors.add(:model, "can't apply age segment: #{segment}")
     end
 
     def segment_element_valid?(element)

--- a/services/cognito/app/operations/segments_apply.rb
+++ b/services/cognito/app/operations/segments_apply.rb
@@ -30,7 +30,7 @@ class SegmentsApply < Ros::ActivityBase
     segment_class = "Segments::#{segment_key.classify}".constantize
     segment_class.call(users: users, segment: segment_value)
   rescue NameError => _e
-    errors.add(:segment, "Can't find segmentation class")
+    errors.add(:segment, "can't find segmentation class")
     nil
   end
 

--- a/services/cognito/app/operations/segments_apply.rb
+++ b/services/cognito/app/operations/segments_apply.rb
@@ -27,8 +27,6 @@ class SegmentsApply < Ros::ActivityBase
   end
 
   def apply_segment(segment_key, segment_value, users, errors)
-    binding.pry
-
     segment_class = "Segments::#{segment_key.classify}".constantize
     segment_class.call(users: users, segment: segment_value)
   rescue NameError => _e

--- a/services/cognito/app/operations/segments_apply.rb
+++ b/services/cognito/app/operations/segments_apply.rb
@@ -27,6 +27,8 @@ class SegmentsApply < Ros::ActivityBase
   end
 
   def apply_segment(segment_key, segment_value, users, errors)
+    binding.pry
+
     segment_class = "Segments::#{segment_key.classify}".constantize
     segment_class.call(users: users, segment: segment_value)
   rescue NameError => _e

--- a/services/cognito/app/operations/segments_apply.rb
+++ b/services/cognito/app/operations/segments_apply.rb
@@ -3,6 +3,7 @@
 class SegmentsApply < Ros::ActivityBase
   step :init
   step :apply_segments
+  failed :unset_model
 
   private
 
@@ -31,5 +32,9 @@ class SegmentsApply < Ros::ActivityBase
   rescue NameError => _e
     errors.add(:segment, "Can't find segmentation class")
     nil
+  end
+
+  def unset_model(ctx, **)
+    ctx[:model] = nil
   end
 end

--- a/services/cognito/spec/operations/pool_create_spec.rb
+++ b/services/cognito/spec/operations/pool_create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PoolCreate, type: :operation do
     let(:pool_name) { 'sample pool' }
     let(:op_params) { { name: pool_name } }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to eq true
       expect(op_result.model.persisted?).to eq true
       expect(op_result.model.system_generated?).to eq false

--- a/services/cognito/spec/operations/pool_create_spec.rb
+++ b/services/cognito/spec/operations/pool_create_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe PoolCreate, type: :operation do
     let(:op_params) { { name: pool_name } }
 
     it 'returns successfull result' do
-      expect(op_result.success?).to be_truthy
-      expect(op_result.model.persisted?).to be_truthy
-      expect(op_result.model.system_generated?).to be_falsey
+      expect(op_result.success?).to eq true
+      expect(op_result.model.persisted?).to eq true
+      expect(op_result.model.system_generated?).to eq false
       expect(op_result.model.name).to eq(pool_name)
     end
   end
@@ -32,8 +32,8 @@ RSpec.describe PoolCreate, type: :operation do
       let(:segmented_users) { users.sample(1) }
 
       it 'returns successfull result' do
-        expect(op_result.success?).to be_truthy
-        expect(op_result.model.system_generated?).to be_truthy
+        expect(op_result.success?).to eq true
+        expect(op_result.model.system_generated?).to eq true
         expect(op_result.model.users.size).to eq(1)
       end
     end
@@ -42,8 +42,8 @@ RSpec.describe PoolCreate, type: :operation do
       let(:segmented_users) { users }
 
       it 'returns successfull result' do
-        expect(op_result.success?).to be_truthy
-        expect(op_result.model.system_generated?).to be_truthy
+        expect(op_result.success?).to eq true
+        expect(op_result.model.system_generated?).to eq true
         expect(op_result.model.users.size).to eq(5)
       end
     end
@@ -52,9 +52,19 @@ RSpec.describe PoolCreate, type: :operation do
       let(:segmented_users) { users.sample(0) }
 
       it 'returns unsuccessfull result' do
-        expect(op_result.success?).to be_falsey
+        expect(op_result.success?).to eq false
         expect(op_result.errors[:users].first).to eq("Can't fetch users for pool")
       end
     end
   end
+
+  context 'when SegmentsApply operation fails' do
+    before do
+      # NOTE: Segment agnostic spec
+      allow(SegmentsApply).to receive_message_chain(:call, :success?).and_return(false)
+    end
+  end
+
+  # TODO: handle case where SegmentsApply operation fails
+  # TODO: handle case where SegmentsApply count is zero -> should still create the pool
 end

--- a/services/cognito/spec/operations/pool_create_spec.rb
+++ b/services/cognito/spec/operations/pool_create_spec.rb
@@ -71,7 +71,4 @@ RSpec.describe PoolCreate, type: :operation do
       end
     end
   end
-
-  # TODO: handle case where SegmentsApply operation fails
-  # TODO: handle case where SegmentsApply count is zero -> should still create the pool
 end

--- a/services/cognito/spec/operations/pool_create_spec.rb
+++ b/services/cognito/spec/operations/pool_create_spec.rb
@@ -25,43 +25,50 @@ RSpec.describe PoolCreate, type: :operation do
 
     before do
       # NOTE: Segment agnostic spec
-      allow(SegmentsApply).to receive_message_chain(:call, :model).and_return(segmented_users)
+      allow(SegmentsApply).to receive(:call).and_return fake_result
     end
 
-    context 'with segment specified' do
-      let(:segmented_users) { users.sample(1) }
+    context 'when segments are applied successfully' do
+      let(:fake_result) { OpenStruct.new("success?": true, model: segmented_users) }
 
-      it 'returns successfull result' do
-        expect(op_result.success?).to eq true
-        expect(op_result.model.system_generated?).to eq true
-        expect(op_result.model.users.size).to eq(1)
+      context 'with segment specified' do
+        let(:segmented_users) { users.sample(1) }
+
+        it 'returns successful result' do
+          expect(op_result.success?).to eq true
+          expect(op_result.model.system_generated?).to eq true
+          expect(op_result.model.users.size).to eq(1)
+        end
+      end
+
+      context 'without segments specified' do
+        let(:segmented_users) { users }
+
+        it 'returns successful result' do
+          expect(op_result.success?).to eq true
+          expect(op_result.model.system_generated?).to eq true
+          expect(op_result.model.users.size).to eq(5)
+        end
+      end
+
+      context 'when segment does not match any users' do
+        let(:segmented_users) { [] }
+
+        it 'returns successful result' do
+          expect(op_result.success?).to eq true
+          expect(op_result.model.system_generated?).to eq true
+          expect(op_result.model.users.size).to eq(0)
+        end
       end
     end
 
-    context 'without segments specified' do
-      let(:segmented_users) { users }
+    context 'when SegmentsApply operation fails' do
+      let(:fake_result) { OpenStruct.new("success?": false) }
 
-      it 'returns successfull result' do
-        expect(op_result.success?).to eq true
-        expect(op_result.model.system_generated?).to eq true
-        expect(op_result.model.users.size).to eq(5)
-      end
-    end
-
-    context 'with non-matching segment' do
-      let(:segmented_users) { users.sample(0) }
-
-      it 'returns unsuccessfull result' do
+      it 'fails the operation' do
         expect(op_result.success?).to eq false
-        expect(op_result.errors[:users].first).to eq("Can't fetch users for pool")
+        expect(op_result.errors[:users].first).to eq('Failed to apply segment')
       end
-    end
-  end
-
-  context 'when SegmentsApply operation fails' do
-    before do
-      # NOTE: Segment agnostic spec
-      allow(SegmentsApply).to receive_message_chain(:call, :success?).and_return(false)
     end
   end
 

--- a/services/cognito/spec/operations/segments/age_spec.rb
+++ b/services/cognito/spec/operations/segments/age_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Segments::Age, type: :operation do
   context 'specific age' do
     let(:segment) { 21 }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(1)
     end
@@ -24,7 +24,7 @@ RSpec.describe Segments::Age, type: :operation do
   context 'age range' do
     let(:segment) { { from: 18, to: 21 } }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(3)
     end
@@ -33,7 +33,7 @@ RSpec.describe Segments::Age, type: :operation do
   context 'age array' do
     let(:segment) { [16, 32, 64, 70] }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(3)
     end
@@ -48,7 +48,7 @@ RSpec.describe Segments::Age, type: :operation do
       ]
     end
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(6)
     end

--- a/services/cognito/spec/operations/segments/birthday_spec.rb
+++ b/services/cognito/spec/operations/segments/birthday_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Segments::Birthday, type: :operation do
   context 'birthday this day' do
     let(:segment) { 'this_day' }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(2)
     end
@@ -31,7 +31,7 @@ RSpec.describe Segments::Birthday, type: :operation do
   context 'birthday this month' do
     let(:segment) { 'this_month' }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(5)
     end
@@ -40,7 +40,7 @@ RSpec.describe Segments::Birthday, type: :operation do
   context 'wrong segment value' do
     let(:segment) { 'wrong_walue' }
 
-    it 'returns ussuccessfull result' do
+    it 'returns unsuccessful result' do
       expect(op_result.success?).to be_falsey
     end
   end

--- a/services/cognito/spec/operations/segments/except_ids_spec.rb
+++ b/services/cognito/spec/operations/segments/except_ids_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Segments::ExceptIds, type: :operation do
 
   let(:segment) { users.sample(3).pluck(:id) }
 
-  it 'returns successfull result' do
+  it 'returns successful result' do
     expect(op_result.success?).to be_truthy
     expect(op_result.model.size).to eq(2)
   end

--- a/services/cognito/spec/operations/segments/gender_spec.rb
+++ b/services/cognito/spec/operations/segments/gender_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Segments::Gender, type: :operation do
   context 'specific gender' do
     let(:segment) { 'male' }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(1)
     end
@@ -24,7 +24,7 @@ RSpec.describe Segments::Gender, type: :operation do
   context 'any gender' do
     let(:segment) { 'any' }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(3)
     end
@@ -33,7 +33,7 @@ RSpec.describe Segments::Gender, type: :operation do
   context 'several genders' do
     let(:segment) { %w[male other] }
 
-    it 'returns successfull result' do
+    it 'returns successful result' do
       expect(op_result.success?).to be_truthy
       expect(op_result.model.size).to eq(2)
     end

--- a/services/cognito/spec/operations/segments_apply_spec.rb
+++ b/services/cognito/spec/operations/segments_apply_spec.rb
@@ -31,15 +31,20 @@ RSpec.describe SegmentsApply, type: :operation do
 
     context 'when one segment fails to apply' do
       let(:segments) { { 'age': { 'from': '10', 'to': '15' }, 'gender': 'male' }.as_json }
+      let(:dummy_errors) do
+        errors = ActiveModel::Errors.new(Segments::Age.new)
+        errors.add(:model, "can't apply age segment")
+        errors
+      end
 
       before do
-        allow(Segments::Age).to receive(:call).and_return(OpenStruct.new("failure?": true))
+        allow(Segments::Age).to receive(:call).and_return(OpenStruct.new("failure?": true, errors: dummy_errors))
       end
 
       it 'returns failure result' do
         expect(op_result.failure?).to eq true
         expect(op_result.model).to eq nil
-        expect(op_result.errors.full_messages).to eq ["Segment can't find segmentation class"]
+        expect(op_result.errors.full_messages).to eq ["Model can't apply age segment"]
       end
     end
   end

--- a/services/cognito/spec/operations/segments_apply_spec.rb
+++ b/services/cognito/spec/operations/segments_apply_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SegmentsApply, type: :operation do
     create_list(:user, 5)
   end
 
-  it 'returns successfull result' do
+  it 'returns successful result' do
     expect(op_result.success?).to eq true
     expect(op_result.model.size).to eq(5)
   end

--- a/services/cognito/spec/operations/segments_apply_spec.rb
+++ b/services/cognito/spec/operations/segments_apply_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe SegmentsApply, type: :operation do
     it 'returns failure result' do
       expect(op_result.failure?).to eq true
       expect(op_result.model).to eq nil
+      expect(op_result.errors.full_messages).to eq ["Segment can't find segmentation class"]
     end
   end
 

--- a/services/cognito/spec/operations/segments_apply_spec.rb
+++ b/services/cognito/spec/operations/segments_apply_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe SegmentsApply, type: :operation do
   let(:op_result) { described_class.call(op_params) }
+  let(:op_params) { { users: User.all, segments: segments } }
+  let(:segments) { {} }
 
   before do
     create_list(:user, 5)
   end
 
   context 'no segments are passed' do
-    let(:op_params) { { users: User.all, segments: {} } }
-
     it 'returns successful result' do
       expect(op_result.success?).to eq true
       expect(op_result.model.size).to eq(5)
@@ -19,15 +19,28 @@ RSpec.describe SegmentsApply, type: :operation do
   end
 
   context 'multiple segments are sent as attribute' do
-    let(:op_params) { { users: User.all, segments: { 'bananas': '10', 'gender': 'male' } } }
+    context 'when one segment does not exist' do
+      let(:segments) { { 'bananas': '10', 'gender': 'male' }.as_json }
 
-    it 'returns failure result' do
-      expect(op_result.failure?).to eq true
-      expect(op_result.model).to eq nil
-      expect(op_result.errors.full_messages).to eq ["Segment can't find segmentation class"]
+      it 'returns failure result' do
+        expect(op_result.failure?).to eq true
+        expect(op_result.model).to eq nil
+        expect(op_result.errors.full_messages).to eq ["Segment can't find segmentation class"]
+      end
+    end
+
+    context 'when one segment fails to apply' do
+      let(:segments) { { 'age': { 'from': '10', 'to': '15' }, 'gender': 'male' }.as_json }
+
+      before do
+        allow(Segments::Age).to receive(:call).and_return(OpenStruct.new("failure?": true))
+      end
+
+      it 'returns failure result' do
+        expect(op_result.failure?).to eq true
+        expect(op_result.model).to eq nil
+        expect(op_result.errors.full_messages).to eq ["Segment can't find segmentation class"]
+      end
     end
   end
-
-  # TODO: cover case where multiple segments are passed and one of them fails
-  # TODO: cover case where segment is inexistent (NameError raised)
 end

--- a/services/cognito/spec/operations/segments_apply_spec.rb
+++ b/services/cognito/spec/operations/segments_apply_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe SegmentsApply, type: :operation do
   end
 
   it 'returns successfull result' do
-    expect(op_result.success?).to be_truthy
+    expect(op_result.success?).to eq true
     expect(op_result.model.size).to eq(5)
   end
+
+  # TODO: cover case where multiple segments are passed and one of them fails
+  # TODO: cover case where segment is inexistent (NameError raised)
 end

--- a/services/cognito/spec/operations/segments_apply_spec.rb
+++ b/services/cognito/spec/operations/segments_apply_spec.rb
@@ -3,16 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe SegmentsApply, type: :operation do
-  let(:op_params) { { users: User.all, segments: {} } }
   let(:op_result) { described_class.call(op_params) }
 
   before do
     create_list(:user, 5)
   end
 
-  it 'returns successful result' do
-    expect(op_result.success?).to eq true
-    expect(op_result.model.size).to eq(5)
+  context 'no segments are passed' do
+    let(:op_params) { { users: User.all, segments: {} } }
+
+    it 'returns successful result' do
+      expect(op_result.success?).to eq true
+      expect(op_result.model.size).to eq(5)
+    end
+  end
+
+  context 'multiple segments are sent as attribute' do
+    let(:op_params) { { users: User.all, segments: { 'bananas': '10', 'gender': 'male' } } }
+
+    it 'returns failure result' do
+      expect(op_result.failure?).to eq true
+      expect(op_result.model).to eq nil
+    end
   end
 
   # TODO: cover case where multiple segments are passed and one of them fails

--- a/services/storage/spec/requests/files_spec.rb
+++ b/services/storage/spec/requests/files_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Files requests', type: :request do
       context 'Image upload' do
         let(:file) { fixture_file_upload(Rails.root.join('..', 'fixtures', 'image_fixture.jpg'), 'image/png') }
 
-        it 'returns successfull response' do
+        it 'returns successful response' do
           expect(response).to be_successful
         end
 
@@ -37,7 +37,7 @@ RSpec.describe 'Files requests', type: :request do
       context 'Document upload' do
         let(:file) { fixture_file_upload(Rails.root.join('..', 'fixtures', 'csv_fixture.csv'), 'text/csv') }
 
-        it 'returns successfull response' do
+        it 'returns successful response' do
           expect(response).to be_successful
         end
 


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Valid campaign created is stuck at scheduled status for more than half an hour](https://perxtechnologies.atlassian.net/browse/PW-3165)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- If final pool is empty, create it anyway
- If apply segment fails, then return a failed operation with no users
- Updated test coverage
- Fixed typos

# How does the implementation addresses the problem

After this has been merged we are mostly allowing pools to be created even if no users match the segments passed. It also checks operation results to ensure that if any of the operation fails, then no unexpected errors are raised.

