### PR TITLE
Pw 2904 rake task to backfill activerecord events

### DIFF
--- a/lib/core/app/models/concerns/ros/application_record_concern.rb
+++ b/lib/core/app/models/concerns/ros/application_record_concern.rb
@@ -46,9 +46,13 @@ module Ros
       end
 
       def type_of_callback_trigger
+        triggered_action = 'update'
+
         %i[create update destroy].each do |action|
-          return action.to_s if transaction_include_any_action?([action])
+          triggered_action = action.to_s if transaction_include_any_action?([action])
         end
+
+        triggered_action
       end
     end
   end

--- a/lib/core/lib/tasks/cloud_event_stream.rake
+++ b/lib/core/lib/tasks/cloud_event_stream.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :ros do
+  namespace :cloud_event_stream do
+    desc 'Log'
+    task :log, [:timestamp] => :environment do
+      next unless Settings.event_logging.enabled
+
+      ApplicationRecord.descendants.each do |model|
+        Rake::Task['ros:cloud_event_stream:log_for_model'].invoke(model, args[:timestamp])
+      end
+    end
+
+    task :log_for_model, [:model, :timestamp] :environment do |task, args|
+      next unless Settings.event_logging.enabled
+
+      model = args[:model].to_s.classify.constantize
+      timestamp = Time.zone.parse(args[:timestamp] || '0000-01-01')
+      type = "#{Settings.service_name}.#{model.name.underscore.downcase}"
+      Tenant.all.each do |t|
+        next if t.schema_name == 'public'
+        Apartment::Tenant.switch(t.schema_name) do
+          model.where('created_at >= ?', timestamp).each do |record|
+            Ros::CloudEventStreamJob.perform_now(type: type, message_id: record.id, data: record.cloud_event_data)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/core/lib/tasks/cloud_event_stream.rake
+++ b/lib/core/lib/tasks/cloud_event_stream.rake
@@ -3,7 +3,7 @@
 namespace :ros do
   namespace :cloud_event_stream do
     desc 'Log'
-    task :log, [:timestamp] => :environment do
+    task :log, [:timestamp] => :environment do |task, args|
       next unless Settings.event_logging.enabled
 
       ApplicationRecord.descendants.each do |model|
@@ -11,7 +11,7 @@ namespace :ros do
       end
     end
 
-    task :log_for_model, [:model, :timestamp] :environment do |task, args|
+    task :log_for_model, [:model, :timestamp] => :environment do |task, args|
       next unless Settings.event_logging.enabled
 
       model = args[:model].to_s.classify.constantize

--- a/lib/core/lib/tasks/cloud_event_stream.rake
+++ b/lib/core/lib/tasks/cloud_event_stream.rake
@@ -2,16 +2,16 @@
 
 namespace :ros do
   namespace :cloud_event_stream do
-    desc 'Log'
-    task :log, [:timestamp] => :environment do |task, args|
+    desc 'backfill active records of each TENANTS from a SERVICE'
+    task :backfill, %i[timestamp] => :environment do |_task, args|
       next unless Settings.event_logging.enabled
 
       ApplicationRecord.descendants.each do |model|
-        Rake::Task['ros:cloud_event_stream:log_for_model'].invoke(model, args[:timestamp])
+        Rake::Task['ros:cloud_event_stream:backfill_a_model'].invoke(model, args[:timestamp])
       end
     end
 
-    task :log_for_model, [:model, :timestamp] => :environment do |task, args|
+    task :backfill_a_model, %i[model timestamp] => :environment do |_task, args|
       next unless Settings.event_logging.enabled
 
       model = args[:model].to_s.classify.constantize
@@ -19,8 +19,9 @@ namespace :ros do
       type = "#{Settings.service_name}.#{model.name.underscore.downcase}"
       Tenant.all.each do |t|
         next if t.schema_name == 'public'
+
         Apartment::Tenant.switch(t.schema_name) do
-          model.where('created_at >= ?', timestamp).each do |record|
+          model.where('updated_at >= ?', timestamp).each do |record|
             Ros::CloudEventStreamJob.perform_now(type: type, message_id: record.id, data: record.cloud_event_data)
           end
         end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Create Rspec Shared Context for Cognito user](https://perxtechnologies.atlassian.net/browse/PW-1351)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- type_of_callback_trigger to return `update` as default and to return only one action instead of all
- Added rake tasks to backfill active records from individual services

# How does the implementation addresses the problem

After merging this, we are providing the ability to backfill the missing data to fluentd. 