### PR TITLE
[Chore] Renable sms sending from event process

### DIFF
--- a/services/comm/app/operations/event_process.rb
+++ b/services/comm/app/operations/event_process.rb
@@ -22,15 +22,12 @@ class EventProcess < Ros::ActivityBase
   def create_messages_for_pool(_ctx, event:, template:, campaign:, **)
     event.process!
     event.users.each do |user|
-      _content = template.render(user: user, campaign: campaign)
-      # TODO: Disabling actual SMS sending on EventProcess until
-      # FE is not creating events at the same time as a campaign
-      # PW-1909: Temporarily uncommenting this
-      # MessageCreate.call(params: { to: user.phone_number,
-      #                             provider: event.provider,
-      #                             channel: event.channel,
-      #                             body: content,
-      #                             owner: event })
+      content = template.render(user: user, campaign: campaign)
+      MessageCreate.call(params: { to: user.phone_number,
+                                   provider: event.provider,
+                                   channel: event.channel,
+                                   body: content,
+                                   owner: event })
     end
     event.publish!
   end

--- a/services/comm/app/resources/message_resource.rb
+++ b/services/comm/app/resources/message_resource.rb
@@ -17,6 +17,12 @@ class MessageResource < Comm::ApplicationResource
     records.sent_to(user.phone_number)
   }
 
+  def provider_id=(_provider_id)
+    # TODO: If the tenant has a provider set, use the tenant's provider
+    # else default to platform default provider
+    @model.provider_id = Providers::Aws.first.id
+  end
+
   def fetchable_fields
     super + [:provider_msg_id]
   end


### PR DESCRIPTION
- N.a

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Re-enable SMS sending when processing events
- Defaulting SMS being sent by AWS provider

# How does the implementation addresses the problem

This gets us one step closer to a better sms sending.
