### PR TITLE
[Hotfix] Avro Builder to cast decimal as string

### DIFF
--- a/lib/core/lib/generators/avro/avro_builder.rb
+++ b/lib/core/lib/generators/avro/avro_builder.rb
@@ -9,7 +9,7 @@ class AvroBuilder
     datetime: 'long',
     jsonb: 'string',
     float: 'double',
-    decimal: 'bytes',
+    decimal: 'string',
     boolean: 'boolean'
   }.freeze
 
@@ -48,13 +48,6 @@ class AvroBuilder
       {
         "type": DICTIONARY[column.sql_type_metadata.type],
         "logicalType": 'timestamp-millis'
-      }
-    when :decimal
-      {
-        "type": DICTIONARY[column.sql_type_metadata.type],
-        "logicalType": 'decimal',
-        "precision": column.sql_type_metadata.precision,
-        "scale": column.sql_type_metadata.scale
       }
     else
       DICTIONARY[column.sql_type_metadata.type] || 'string'


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
- No Jira case

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Avro builder updated.

# How does the implementation addresses the problem

After merging this, we will have type `string` in avro schemas for all decimal columns.
