### PR TITLE
PW-3145: Allow TenantHandler class to accept transaction class name

### DIFF
--- a/lib/core/lib/ros/scheduler/tenant_handler.rb
+++ b/lib/core/lib/ros/scheduler/tenant_handler.rb
@@ -19,11 +19,12 @@
 module Ros
   module Scheduler
     class TenantHandler
-      attr_reader :count, :job_class, :queue
+      attr_reader :count, :job_class, :queue, :transaction_klass
 
-      def initialize(job_class:, queue_name: nil)
+      def initialize(job_class:, queue_name: nil, transaction_klass: '::Transaction')
         @count = 0
         @job_class = job_class
+        @transaction_klass = transaction_klass
         @queue = Sidekiq::Queue.new(queue_name || job_class.queue_name)
       end
 
@@ -36,7 +37,7 @@ module Ros
 
       # NOTE: Override in subclass to implement a custom block
       def perform_later(tenant)
-        job_class.perform_later(params: { account_id: tenant.account_id })
+        job_class.perform_later(params: { account_id: tenant.account_id, transaction_klass: transaction_klass })
       end
 
       def per_tenant


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[TransactionCleanup is looking for the wrong result type](https://perxtechnologies.atlassian.net/browse/PW-3145)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Allow `TenantHandler` class receive `transaction_klass` params so that the transaction look class is more dynamic

# How does the implementation addresses the problem

After merging this, what are we providing extra.
