### PR TITLE
Fix avro BigDecimal convert to string

### DIFF
--- a/lib/core/app/models/concerns/ros/application_record_concern.rb
+++ b/lib/core/app/models/concerns/ros/application_record_concern.rb
@@ -27,7 +27,7 @@ module Ros
       end
 
       def cloud_event_data
-        attributes_to_modify = %i[jsonb datetime]
+        attributes_to_modify = %i[jsonb datetime decimal]
         avro_attributes = attributes.map do |name, value|
           next [name, value] unless attributes_to_modify.include? column_for_attribute(name).type
 
@@ -42,6 +42,8 @@ module Ros
           [name, value.to_s]
         elsif column_for_attribute(name).type == :datetime
           [name, (value.to_f * 1000).to_i]
+        elsif column_for_attribute(name).type == :decimal
+          [name, value.to_s('F')]
         end
       end
 


### PR DESCRIPTION
This fixes the avro data type for BigDecimal, we are generating avro schema as string.