### PR TITLE
core: also stub with_params

### DIFF
--- a/lib/core/spec/support/helpers/association_resource_stub.rb
+++ b/lib/core/spec/support/helpers/association_resource_stub.rb
@@ -7,11 +7,12 @@ module AssociationResource
     def stubbed_resource(resource:, attributes:)
       attributes = Array.wrap(attributes)
 
+      allow(resource).to receive(:all).and_return attributes
       allow(resource).to receive(:find).and_return attributes
       allow(resource).to receive(:first).and_return attributes.first
-      allow(resource).to receive(:all).and_return attributes
-      allow(resource).to receive(:where).and_return resource
       allow(resource).to receive(:includes).and_return resource
+      allow(resource).to receive(:where).and_return resource
+      allow(resource).to receive(:with_params).and_return attributes
     end
 
     def stub_resource(model:, resource:, attributes:)

--- a/lib/sdk/lib/ros_sdk/sdk.rb
+++ b/lib/sdk/lib/ros_sdk/sdk.rb
@@ -25,6 +25,11 @@ module Ros
 
     class Base < JsonApiClient::Resource
       self.paginator = JsonApiPaginator
+      # TODO: the way our helpers are designed, find is called without params so
+      # we cannot set this to true, but we really should redesign the general
+      # resource helpers and change this
+      self.raise_on_blank_find_param = false
+
       attr_writer :to_gid
 
       def to_gid


### PR DESCRIPTION
On `stubbed_resource` also stub `with_params`.