### PR TITLE
PW-3145: Use RequestStore to store user credential 

### DIFF
--- a/lib/core/Gemfile.lock
+++ b/lib/core/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       json_api_client (= 1.15.0)
       jwt (= 2.2.1)
       pry (= 0.12.2)
+      request_store (= 1.5.0)
 
 PATH
   remote: .
@@ -312,6 +313,8 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
+    request_store (1.5.0)
+      rack (>= 1.4)
     ros-apartment (2.3.0)
       activerecord (>= 3.1.2, < 6.1)
       parallel (>= 0.7.1)

--- a/lib/core/lib/ros/scheduler/tenant_handler.rb
+++ b/lib/core/lib/ros/scheduler/tenant_handler.rb
@@ -44,6 +44,7 @@ module Ros
           Tenant.find_each do |tenant|
             next if job_enqueued(tenant)
 
+            sleep(1)
             tenant.switch do
               Rails.logger.debug "Running job on #{tenant.account_id} (#{count})"
               yield tenant

--- a/lib/core/lib/ros/scheduler/tenant_handler.rb
+++ b/lib/core/lib/ros/scheduler/tenant_handler.rb
@@ -44,7 +44,6 @@ module Ros
           Tenant.find_each do |tenant|
             next if job_enqueued(tenant)
 
-            sleep(1)
             tenant.switch do
               Rails.logger.debug "Running job on #{tenant.account_id} (#{count})"
               yield tenant

--- a/lib/sdk/Gemfile.lock
+++ b/lib/sdk/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       json_api_client (= 1.15.0)
       jwt (= 2.2.1)
       pry (= 0.12.2)
+      request_store (= 1.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -32,6 +33,7 @@ GEM
       deep_merge (~> 1.2.1)
       dry-validation (>= 0.12.2)
     deep_merge (1.2.1)
+    diff-lcs (1.3)
     dry-configurable (0.9.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
@@ -95,6 +97,21 @@ GEM
     public_suffix (4.0.2)
     rack (2.0.8)
     rake (12.3.3)
+    request_store (1.5.0)
+      rack (>= 1.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -108,6 +125,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   rake (~> 12.0)
   ros_sdk!
+  rspec (~> 3.9.0)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/sdk/lib/ros_sdk/sdk.rb
+++ b/lib/sdk/lib/ros_sdk/sdk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'globalid'
+require 'request_store'
 
 module Ros
   module Sdk

--- a/lib/sdk/lib/ros_sdk/sdk.rb
+++ b/lib/sdk/lib/ros_sdk/sdk.rb
@@ -57,30 +57,27 @@ module Ros
         end
 
         def request_headers=(value)
-          RequestStore.store[:request_headers] = value
+          ::RequestStore.store[:request_headers] = value
         end
 
         def request_headers
-          # @request_headers ||= {}
-          RequestStore.store[:request_headers] ||= {}
+          ::RequestStore.store[:request_headers] ||= {}
         end
 
         def partition
-          # @partition ||= Settings.partition_name
-          RequestStore.store[:partition] ||= Setting.partition_name
+          ::RequestStore.store[:partition] ||= Setting.partition_name
         end
 
         def partition=(value)
-          RequestStore.store[:partition] = value
+          ::RequestStore.store[:partition] = value
         end
 
         def authorization
-          # @authorization ||= "#{Settings.auth_type} #{access_key_id}:#{secret_access_key}"
-          RequestStore.store[:authorization] ||= "#{Settings.auth_type} #{access_key_id}:#{secret_access_key}"
+          ::RequestStore.store[:authorization] ||= "#{Settings.auth_type} #{access_key_id}:#{secret_access_key}"
         end
 
         def authorization=(value)
-          RequestStore.store[:authorization] = value
+          ::RequestStore.store[:authorization] = value
         end
       end
     end

--- a/lib/sdk/lib/ros_sdk/sdk.rb
+++ b/lib/sdk/lib/ros_sdk/sdk.rb
@@ -50,23 +50,37 @@ module Ros
     class Credential
       class << self
         attr_accessor :access_key_id, :secret_access_key, :region
-        attr_writer :partition, :authorization, :request_headers
 
         def configure(access_key_id: nil, secret_access_key: nil)
           self.access_key_id = access_key_id
           self.secret_access_key = secret_access_key
         end
 
+        def request_headers=(value)
+          RequestStore.store[:request_headers] = value
+        end
+
         def request_headers
-          @request_headers ||= {}
+          # @request_headers ||= {}
+          RequestStore.store[:request_headers] ||= {}
         end
 
         def partition
-          @partition ||= Settings.partition_name
+          # @partition ||= Settings.partition_name
+          RequestStore.store[:partition] ||= Setting.partition_name
+        end
+
+        def partition=(value)
+          RequestStore.store[:partition] = value
         end
 
         def authorization
-          @authorization ||= "#{Settings.auth_type} #{access_key_id}:#{secret_access_key}"
+          # @authorization ||= "#{Settings.auth_type} #{access_key_id}:#{secret_access_key}"
+          RequestStore.store[:authorization] ||= "#{Settings.auth_type} #{access_key_id}:#{secret_access_key}"
+        end
+
+        def authorization=(value)
+          RequestStore.store[:authorization] = value
         end
       end
     end

--- a/lib/sdk/ros_sdk.gemspec
+++ b/lib/sdk/ros_sdk.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json_api_client', '1.15.0'
   spec.add_dependency 'jwt', '2.2.1'
   spec.add_dependency 'pry', '0.12.2'
+  spec.add_dependency 'request_store', '1.5.0'
 
   spec.add_development_dependency 'awesome_print', '1.8.0'
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/sdk/ros_sdk.gemspec
+++ b/lib/sdk/ros_sdk.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'awesome_print', '1.8.0'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
 end

--- a/lib/sdk/spec/ros_sdk/sdk_spec.rb
+++ b/lib/sdk/spec/ros_sdk/sdk_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Ros::Sdk::Credential do
+  context 'when setting configure' do
+    before do
+      described_class.configure(access_key_id: 'secret', secret_access_key: 'another secret')
+    end
+
+    it 'sets access key correctly' do
+      expect(described_class.access_key_id).to eq 'secret'
+    end
+
+    it 'stores request headers in RequestStore' do
+      expect(described_class.secret_access_key).to eq 'another secret'
+    end
+  end
+
+  context 'when setting request headers' do
+    before do
+      described_class.request_headers = { some: 'headers', goes: 'here' }
+    end
+
+    it 'sets request headers correctly' do
+      expect(described_class.request_headers).to eq(some: 'headers', goes: 'here')
+    end
+
+    it 'stores request headers in RequestStore' do
+      expect(::RequestStore.store[:request_headers]).to eq described_class.request_headers
+    end
+  end
+
+  context 'when setting partition' do
+    before do
+      described_class.partition = 'anything'
+    end
+
+    it 'sets partition correctly' do
+      expect(described_class.partition).to eq 'anything'
+    end
+
+    it 'stores partition in RequestStore' do
+      expect(::RequestStore.store[:partition]).to eq described_class.partition
+    end
+  end
+
+  context 'when setting authorization' do
+    before do
+      described_class.authorization = 'anything'
+    end
+
+    it 'sets partition correctly' do
+      expect(described_class.authorization).to eq 'anything'
+    end
+
+    it 'stores partition in RequestStore' do
+      expect(::RequestStore.store[:authorization]).to eq described_class.authorization
+    end
+  end
+end

--- a/lib/sdk/spec/ros_sdk/sdk_spec.rb
+++ b/lib/sdk/spec/ros_sdk/sdk_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Ros::Sdk::Credential do
       expect(described_class.access_key_id).to eq 'secret'
     end
 
-    it 'stores request headers in RequestStore' do
+    it 'stores secret access key correctly' do
       expect(described_class.secret_access_key).to eq 'another secret'
     end
   end
@@ -50,11 +50,11 @@ RSpec.describe Ros::Sdk::Credential do
       described_class.authorization = 'anything'
     end
 
-    it 'sets partition correctly' do
+    it 'sets authorization correctly' do
       expect(described_class.authorization).to eq 'anything'
     end
 
-    it 'stores partition in RequestStore' do
+    it 'stores authorization in RequestStore' do
       expect(::RequestStore.store[:authorization]).to eq described_class.authorization
     end
   end

--- a/lib/sdk/spec/spec_helper.rb
+++ b/lib/sdk/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'pry'
+
+require 'active_support/core_ext/class/attribute'
+require 'json_api_client'
+require 'faraday_middleware'
+require 'ros_sdk/sdk'
+require 'ros_sdk/middleware'
+require 'ros_sdk/models'
+
+Dir[File.expand_path('lib/ros_sdk/*.rb')].each { |f| require f }


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Use RequestStore to store user credential instead of class attributes](https://perxtechnologies.atlassian.net/browse/PW-3145)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Use RequestStore to store user credential Instead class attributes, so that the credential is properly binding the incoming request.

# How does the implementation addresses the problem

After merging this, we should not have any issue where the tenant is not reflecting each other in each service.
