### PR TITLE
[PW-3415] ilike filter

### DIFF
--- a/lib/core/app/resources/ros/application_resource.rb
+++ b/lib/core/app/resources/ros/application_resource.rb
@@ -22,7 +22,7 @@ module Ros
       def descriptions; {} end
 
       def apply_filter(records, filter, value, _options)
-        return super(records, filter, value) unless _allowed_filters[filter][:ilike]
+        return super(records, filter, value) unless _allowed_filters.dig(filter, :ilike)
 
         items = Array.wrap(value[0])
         items = items.map { |n| "%#{n}%" }

--- a/lib/core/app/resources/ros/application_resource.rb
+++ b/lib/core/app/resources/ros/application_resource.rb
@@ -21,13 +21,13 @@ module Ros
     class << self
       def descriptions; {} end
 
-      def apply_filter(records, filter, value, options)
+      def apply_filter(records, filter, value, _options)
         return super(records, filter, value) unless _allowed_filters[filter][:ilike]
 
         items = Array.wrap(value[0])
         items = items.map { |n| "%#{n}%" }
 
-        records = records.where("#{filter} ILIKE ANY (array[?])", items)
+        records.where("#{filter} ILIKE ANY (array[?])", items)
       end
     end
   end

--- a/lib/core/app/resources/ros/application_resource.rb
+++ b/lib/core/app/resources/ros/application_resource.rb
@@ -18,6 +18,17 @@ module Ros
     #   }
     # end
 
-    def self.descriptions; {} end
+    class << self
+      def descriptions; {} end
+
+      def apply_filter(records, filter, value, options)
+        return super(records, filter, value) unless _allowed_filters[filter][:ilike]
+
+        items = Array.wrap(value[0])
+        items = items.map { |n| "%#{n}%" }
+
+        records = records.where("#{filter} ILIKE ANY (array[?])", items)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Make the ilike filter more flexible](https://perxtechnologies.atlassian.net/browse/PW-3415)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- override `apply_filter` JSONAPI Resources to handle `ilike: true` option. This is [documented feature](https://jsonapi-resources.com/v0.10/guide/resources.html#Applying-Filters).

Example:

```ruby
# frozen_string_literal: true

class SomeResource < ApplicationResource
  filter :column_name, ilike: true
end
```

NOTE: Works only with `filter`, not `filters`

# How does the implementation addresses the problem

After merging this, we will be able to use advanced ilike filter on any resource that inherits from `Ros::ApplicationResource`
