### PR TITLE
Allow IAM tenant to accept properties field

### DIFF
--- a/services/iam/app/resources/tenant_resource.rb
+++ b/services/iam/app/resources/tenant_resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TenantResource < Iam::ApplicationResource
-  attributes :schema_name, :account_id, :root_id, :alias, :name, :display_properties # :locale
+  attributes :schema_name, :account_id, :root_id, :alias, :name, :display_properties, :properties # :locale
 
   filter :schema_name
 


### PR DESCRIPTION
# Refer to the issue id if any. Include the link to the issue. E.g:
[Allow IAM tenant to accept properties field](https://perxtechnologies.atlassian.net/browse/PW-3338)

# Describe the changes made. What does this PR changes that might be critical. If any critical decisions have been made, make sure you explain the rationale for these decisions.

- Add `properties` field to tenant resource for IAM

# How does the implementation addresses the problem

After merging this, the user should be able to set the `properties` field when creating a new tenant on IAM service.
